### PR TITLE
fix(docs): render S/R monitor Formula LaTeX + add LaTeX lint (5ipk.5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
           python3 scripts/check_bead_ids.py
           python3 scripts/check_talib_map_drift.py
           python3 scripts/check_api_stubs_drift.py
+          python3 scripts/check_doc_latex.py
 
   rust-gate:
     name: Rust quality gate

--- a/docs/guides/indicators/native/s_r_interaction_monitor_part_67.md
+++ b/docs/guides/indicators/native/s_r_interaction_monitor_part_67.md
@@ -32,10 +32,14 @@ QuantWave implements this via the universal `Next<T>` trait — bit-identical ac
 
 **Implementation** (`quantwave-core/src/indicators/sr_monitor.rs`):
 
-\text{side} = \text{sign}(price - level)\\
-\text{touch if } |level - [L,H]| \le tol\\
-\text{breakout if side flips}\\
-\text{retest if post-breakout distance} \le tol
+\[
+\begin{aligned}
+\text{side} &= \text{sign}(price - level)\\
+\text{touch} &\text{ if } |level - [L,H]| \le tol\\
+\text{breakout} &\text{ if side flips}\\
+\text{retest} &\text{ if post-breakout distance} \le tol
+\end{aligned}
+\]
 
 
 ## Parameters

--- a/scripts/check_doc_latex.py
+++ b/scripts/check_doc_latex.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Fail on undelimited LaTeX math in indicator docs (quantwave-5ipk.5).
+
+Block/inline math must be wrapped in arithmatex delimiters (``\\[ ... \\]``,
+``$$ ... $$``, or ``$ ... $`` / ``\\( ... \\)``) so it renders instead of
+showing as raw ``\\text{...}`` source. Scans real content pages under
+``docs/guides/`` (skipping fenced code blocks and the meta standards doc, which
+intentionally shows bad examples).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+SCAN_DIRS = [DOCS / "guides"]
+# Meta docs that intentionally include "bad" LaTeX examples inside prose/fences.
+SKIP_FILES = {DOCS / "DOCUMENTATION_STANDARDS.md"}
+
+MATH_CMD = re.compile(
+    r"\\(text|frac|sum|prod|sqrt|alpha|beta|gamma|sigma|mu|lambda|le|ge|neq|"
+    r"times|cdot|sin|cos|tan|partial|infty|hat|bar|hbar|int|lim|log|ln)\b"
+)
+
+
+def _undelimited_math_lines(text: str) -> list[tuple[int, str]]:
+    bad: list[tuple[int, str]] = []
+    in_fence = False
+    in_block = False
+    for i, line in enumerate(text.split("\n"), start=1):
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if r"\[" in line:
+            in_block = True
+        has_math = bool(MATH_CMD.search(line))
+        if in_block:
+            if r"\]" in line:
+                in_block = False
+            continue
+        if not has_math:
+            continue
+        # inline-delimited math on this line is fine
+        if "$$" in line or line.count("$") >= 2 or r"\(" in line:
+            continue
+        bad.append((i, stripped[:80]))
+    return bad
+
+
+def main() -> int:
+    violations: list[str] = []
+    for base in SCAN_DIRS:
+        if not base.exists():
+            continue
+        for md in sorted(base.rglob("*.md")):
+            if md in SKIP_FILES:
+                continue
+            text = md.read_text(encoding="utf-8")
+            for lineno, snippet in _undelimited_math_lines(text):
+                violations.append(f"{md.relative_to(ROOT)}:{lineno}: {snippet}")
+
+    if violations:
+        print(
+            f"check_doc_latex: {len(violations)} undelimited LaTeX line(s) "
+            "(wrap in \\[ ... \\] or $$ ... $$):",
+            file=sys.stderr,
+        )
+        for v in violations:
+            print(f"  - {v}", file=sys.stderr)
+        return 1
+    print("check_doc_latex: OK (all math delimited)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Partial progress on **quantwave-5ipk.5** — the LaTeX-rendering slice.

## Fixed
- `s_r_interaction_monitor_part_67.md`'s Formula block was raw `\text{…}` with no delimiters, so arithmatex rendered it as literal source. Wrapped it in `\[ \begin{aligned} … \end{aligned} \]`.
- New `scripts/check_doc_latex.py`, wired into the **Doc & metadata sanity** CI job, lints guide pages for undelimited LaTeX. It reports 4 violations on the pre-fix page and passes after — the TDD contract from the bead.

## Correction (why this PR shrank)
An earlier revision of this branch also rewrote ~170 relative links, based on a link checker I wrote that used **filesystem-relative** resolution. That was wrong: MkDocs uses **directory-URL** resolution (each `.md` is served as `/dir/`, so links need one *more* `../`). The existing `check_doc_drift.py` already validates links with the correct model and **passes clean on `main`** — there were no broken links to fix, and those rewrites were regressions. They've been dropped; this PR now contains only the genuine LaTeX fix + lint.

## Remaining on 5ipk.5 (follow-up)
- `mkdocs build --strict` gate; migrate 162 meta-refresh stubs to `mkdocs-redirects`; `/reference/` `/backtest/` redirects; consolidated mkdocstrings API page. (Broken links and description-duplication depth-lint already pass on main.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)