### PR TITLE
fix(docs): /reference /backtest redirects + Google docstrings + typed options API (5ipk.5)

### DIFF
--- a/docs/backtest/index.md
+++ b/docs/backtest/index.md
@@ -1,0 +1,4 @@
+<!-- redirect-stub:backtest→guides/backtest -->
+<meta http-equiv="refresh" content="0; url=../guides/backtest/">
+
+Redirecting to the [Backtest Engine guide](../guides/backtest/)…

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,4 @@
+<!-- redirect-stub:reference→api -->
+<meta http-equiv="refresh" content="0; url=../api/">
+
+Redirecting to the [Python API Reference](../api/)…

--- a/quantwave-python/python/quantwave/polars.py
+++ b/quantwave-python/python/quantwave/polars.py
@@ -30,6 +30,12 @@ _NSE_LOT_SIZES: dict[str, int] = {
 }
 
 
+# Type aliases for Polars Expr builders: a bare column reference vs. a value
+# that may be a column, an Expr, or a scalar broadcast across the chain.
+_Col = Union[str, pl.Expr]
+_ColOrVal = Union[str, pl.Expr, float, int]
+
+
 def _as_expr(arg: Union[str, pl.Expr, float, int]) -> Union[pl.Expr, float, int]:
     """Column name -> pl.col; Expr / scalar passed through for use in expressions."""
     if isinstance(arg, str):
@@ -106,33 +112,26 @@ class options:
         price_col: str,
         spot: float,
         strike_col: str,
-        r_col_or_val,
-        t_col_or_val,
+        r_col_or_val: _ColOrVal,
+        t_col_or_val: _ColOrVal,
         is_call: bool = True,
     ) -> pl.Expr:
         """Implied Black volatility from market price (annualized decimal).
 
-        Parameters
-        ----------
-        price_col : str
-            Column with option LTP (same units as spot).
-        spot : float
-            Underlying spot price.
-        strike_col : str
-            Strike column.
-        r_col_or_val : str, Expr, or float
-            Risk-free rate (annualized decimal, e.g. 0.065).
-        t_col_or_val : str, Expr, or float
-            Time to expiry in years.
-        is_call : bool
-            True for call, False for put.
+        Args:
+            price_col: Column with option LTP (same units as spot).
+            spot: Underlying spot price.
+            strike_col: Strike column.
+            r_col_or_val: Risk-free rate (annualized decimal, e.g. 0.065), as
+                a column name, Expr, or float.
+            t_col_or_val: Time to expiry in years, as a column name, Expr, or float.
+            is_call: True for call, False for put.
 
-        Examples
-        --------
-        >>> import polars as pl
-        >>> from quantwave.polars import options
-        >>> df = pl.DataFrame({"k": [100.0], "px": [5.0], "t": [0.25]})
-        >>> df.select(options.implied_vol("px", 100.0, "k", 0.05, "t"))  # doctest: +SKIP
+        Examples:
+            >>> import polars as pl
+            >>> from quantwave.polars import options
+            >>> df = pl.DataFrame({"k": [100.0], "px": [5.0], "t": [0.25]})
+            >>> df.select(options.implied_vol("px", 100.0, "k", 0.05, "t"))  # doctest: +SKIP
         """
         exprs: list[pl.Expr] = [pl.col(price_col), pl.col(strike_col)]
         options._handle_arg(exprs, r_col_or_val, "_r_val", length_ref=strike_col)
@@ -147,9 +146,9 @@ class options:
     def bs_call_price(
         spot: float,
         strike_col: str,
-        r_col_or_val,
-        t_col_or_val,
-        sigma_col_or_val,
+        r_col_or_val: _ColOrVal,
+        t_col_or_val: _ColOrVal,
+        sigma_col_or_val: _ColOrVal,
     ) -> pl.Expr:
         """Black–Scholes call price (vectorized native plugin)."""
         exprs: list[pl.Expr] = [pl.col(strike_col)]
@@ -162,9 +161,9 @@ class options:
     def bs_put_price(
         spot: float,
         strike_col: str,
-        r_col_or_val,
-        t_col_or_val,
-        sigma_col_or_val,
+        r_col_or_val: _ColOrVal,
+        t_col_or_val: _ColOrVal,
+        sigma_col_or_val: _ColOrVal,
     ) -> pl.Expr:
         """Black–Scholes put price (vectorized native plugin)."""
         exprs: list[pl.Expr] = [pl.col(strike_col)]
@@ -175,11 +174,11 @@ class options:
 
     @staticmethod
     def bs_delta(
-        iv_col_or_val,
+        iv_col_or_val: _ColOrVal,
         spot: float,
         strike_col: str,
-        r_col_or_val,
-        t_col_or_val,
+        r_col_or_val: _ColOrVal,
+        t_col_or_val: _ColOrVal,
         is_call: bool = True,
     ) -> pl.Expr:
         """Black–Scholes delta (vectorized native plugin)."""
@@ -190,7 +189,13 @@ class options:
         )
 
     @staticmethod
-    def bs_gamma(iv_col_or_val, spot: float, strike_col: str, r_col_or_val, t_col_or_val) -> pl.Expr:
+    def bs_gamma(
+        iv_col_or_val: _ColOrVal,
+        spot: float,
+        strike_col: str,
+        r_col_or_val: _ColOrVal,
+        t_col_or_val: _ColOrVal,
+    ) -> pl.Expr:
         """Black–Scholes gamma (vectorized native plugin)."""
         return _options_plugin(
             options._greeks_inputs(iv_col_or_val, strike_col, r_col_or_val, t_col_or_val),
@@ -199,7 +204,13 @@ class options:
         )
 
     @staticmethod
-    def bs_vega(iv_col_or_val, spot: float, strike_col: str, r_col_or_val, t_col_or_val) -> pl.Expr:
+    def bs_vega(
+        iv_col_or_val: _ColOrVal,
+        spot: float,
+        strike_col: str,
+        r_col_or_val: _ColOrVal,
+        t_col_or_val: _ColOrVal,
+    ) -> pl.Expr:
         """Black–Scholes vega (vectorized native plugin)."""
         return _options_plugin(
             options._greeks_inputs(iv_col_or_val, strike_col, r_col_or_val, t_col_or_val),
@@ -209,11 +220,11 @@ class options:
 
     @staticmethod
     def bs_theta(
-        iv_col_or_val,
+        iv_col_or_val: _ColOrVal,
         spot: float,
         strike_col: str,
-        r_col_or_val,
-        t_col_or_val,
+        r_col_or_val: _ColOrVal,
+        t_col_or_val: _ColOrVal,
         is_call: bool = True,
     ) -> pl.Expr:
         """Black–Scholes theta per calendar day (vectorized native plugin)."""
@@ -225,11 +236,11 @@ class options:
 
     @staticmethod
     def bs_rho(
-        iv_col_or_val,
+        iv_col_or_val: _ColOrVal,
         spot: float,
         strike_col: str,
-        r_col_or_val,
-        t_col_or_val,
+        r_col_or_val: _ColOrVal,
+        t_col_or_val: _ColOrVal,
         is_call: bool = True,
     ) -> pl.Expr:
         """Black–Scholes rho (vectorized native plugin)."""
@@ -240,7 +251,12 @@ class options:
         )
 
     @staticmethod
-    def max_pain(strikes_col, ce_oi_col, pe_oi_col, lot_size_col_or_val):
+    def max_pain(
+        strikes_col: _Col,
+        ce_oi_col: _Col,
+        pe_oi_col: _Col,
+        lot_size_col_or_val: _ColOrVal,
+    ) -> pl.Expr:
         """Max-pain strike for one option chain (whole-chain reduction).
 
         Returns the strike at which total buyer loss is minimised. This is an
@@ -249,28 +265,23 @@ class options:
         per-row Python loop. Apply per expiry snapshot (one chain per call, or
         inside ``group_by(expiry)``).
 
-        Parameters
-        ----------
-        strikes_col : str or Expr
-            Strike prices.
-        ce_oi_col, pe_oi_col : str or Expr
-            Call / put open interest (integer contracts).
-        lot_size_col_or_val : int, float, str, or Expr
-            Contract lot size (scalar per chain).
+        Args:
+            strikes_col: Strike prices, as a column name or Expr.
+            ce_oi_col: Call open interest (integer contracts), as a column name or Expr.
+            pe_oi_col: Put open interest (integer contracts), as a column name or Expr.
+            lot_size_col_or_val: Contract lot size (scalar per chain), as an
+                int, float, column name, or Expr.
 
-        Returns
-        -------
-        pl.Expr
-            Length-1 Float64 (the max-pain strike).
+        Returns:
+            pl.Expr: Length-1 Float64 (the max-pain strike).
 
-        Examples
-        --------
-        >>> import polars as pl
-        >>> from quantwave.polars import options
-        >>> df = pl.DataFrame({"k": [24800.0, 25000.0, 25200.0],
-        ...                    "ce": [10000, 5000, 2000], "pe": [2000, 5000, 10000]})
-        >>> df.select(options.max_pain("k", "ce", "pe", 50).alias("x"))["x"][0]
-        25000.0
+        Examples:
+            >>> import polars as pl
+            >>> from quantwave.polars import options
+            >>> df = pl.DataFrame({"k": [24800.0, 25000.0, 25200.0],
+            ...                    "ce": [10000, 5000, 2000], "pe": [2000, 5000, 10000]})
+            >>> df.select(options.max_pain("k", "ce", "pe", 50).alias("x"))["x"][0]
+            25000.0
         """
         exprs: list[pl.Expr] = []
         s_name = options._handle_arg(exprs, strikes_col, "_s_col")
@@ -291,36 +302,34 @@ class options:
         return pl.struct(exprs).map_batches(_max_pain, return_dtype=pl.Float64)
 
     @staticmethod
-    def strike_pcr(ce_oi_col, pe_oi_col):
+    def strike_pcr(ce_oi_col: _Col, pe_oi_col: _Col) -> pl.Expr:
         """Per-strike Put-Call Ratio (PE_OI / CE_OI), native Polars expression.
 
         Matches ``chain_analytics::strike_pcr``: 0.0 where CE_OI is zero.
 
-        Examples
-        --------
-        >>> import polars as pl
-        >>> from quantwave.polars import options
-        >>> df = pl.DataFrame({"ce": [10000, 2000], "pe": [2000, 10000]})
-        >>> df.select(options.strike_pcr("ce", "pe").alias("x"))["x"].to_list()
-        [0.2, 5.0]
+        Examples:
+            >>> import polars as pl
+            >>> from quantwave.polars import options
+            >>> df = pl.DataFrame({"ce": [10000, 2000], "pe": [2000, 10000]})
+            >>> df.select(options.strike_pcr("ce", "pe").alias("x"))["x"].to_list()
+            [0.2, 5.0]
         """
         ce = _as_expr(ce_oi_col)
         pe = _as_expr(pe_oi_col)
         return pl.when(ce == 0).then(0.0).otherwise(pe / ce)
 
     @staticmethod
-    def chain_pcr(ce_oi_col, pe_oi_col):
+    def chain_pcr(ce_oi_col: _Col, pe_oi_col: _Col) -> pl.Expr:
         """Chain-level Put-Call Ratio: sum(PE_OI) / sum(CE_OI) (0.0 if no CE_OI).
 
         Native Polars aggregation; returns a length-1 Float64.
 
-        Examples
-        --------
-        >>> import polars as pl
-        >>> from quantwave.polars import options
-        >>> df = pl.DataFrame({"ce": [10000, 5000], "pe": [2000, 8000]})
-        >>> df.select(options.chain_pcr("ce", "pe").alias("x"))["x"][0]
-        0.6666666666666666
+        Examples:
+            >>> import polars as pl
+            >>> from quantwave.polars import options
+            >>> df = pl.DataFrame({"ce": [10000, 5000], "pe": [2000, 8000]})
+            >>> df.select(options.chain_pcr("ce", "pe").alias("x"))["x"][0]
+            0.6666666666666666
         """
         ce = _as_expr(ce_oi_col)
         pe = _as_expr(pe_oi_col)
@@ -328,40 +337,41 @@ class options:
         return pl.when(total_ce == 0).then(0.0).otherwise(pe.sum() / total_ce)
 
     @staticmethod
-    def synthetic_futures(strikes_col, ce_ltp_col, pe_ltp_col):
+    def synthetic_futures(strikes_col: _Col, ce_ltp_col: _Col, pe_ltp_col: _Col) -> pl.Expr:
         """Per-strike synthetic future (CE_LTP - PE_LTP + Strike), native expression.
 
-        Examples
-        --------
-        >>> import polars as pl
-        >>> from quantwave.polars import options
-        >>> df = pl.DataFrame({"k": [24800.0], "ce": [250.0], "pe": [10.0]})
-        >>> df.select(options.synthetic_futures("k", "ce", "pe").alias("x"))["x"][0]
-        25040.0
+        Examples:
+            >>> import polars as pl
+            >>> from quantwave.polars import options
+            >>> df = pl.DataFrame({"k": [24800.0], "ce": [250.0], "pe": [10.0]})
+            >>> df.select(options.synthetic_futures("k", "ce", "pe").alias("x"))["x"][0]
+            25040.0
         """
         return _as_expr(ce_ltp_col) - _as_expr(pe_ltp_col) + _as_expr(strikes_col)
 
     @staticmethod
-    def oi_zones(strikes_col, ce_oi_col, pe_oi_col, n_col_or_val):
+    def oi_zones(
+        strikes_col: _Col,
+        ce_oi_col: _Col,
+        pe_oi_col: _Col,
+        n_col_or_val: _ColOrVal,
+    ) -> pl.Expr:
         """Top-N OI support/resistance strikes for one chain (whole-chain reduction).
 
         Resistance = strikes with highest CE_OI; support = highest PE_OI. Computed
         in a single native Rust call (``chain_analytics::oi_zones``); returns a
         length-1 struct of two Float64 lists. Apply per expiry snapshot.
 
-        Returns
-        -------
-        pl.Expr
-            Struct{resistance_strikes: list[f64], support_strikes: list[f64]}.
+        Returns:
+            pl.Expr: Struct{resistance_strikes: list[f64], support_strikes: list[f64]}.
 
-        Examples
-        --------
-        >>> import polars as pl
-        >>> from quantwave.polars import options
-        >>> df = pl.DataFrame({"k": [24800.0, 25000.0, 25200.0],
-        ...                    "ce": [10000, 5000, 2000], "pe": [2000, 5000, 10000]})
-        >>> df.select(options.oi_zones("k", "ce", "pe", 1).alias("z"))["z"][0]["resistance_strikes"]
-        [24800.0]
+        Examples:
+            >>> import polars as pl
+            >>> from quantwave.polars import options
+            >>> df = pl.DataFrame({"k": [24800.0, 25000.0, 25200.0],
+            ...                    "ce": [10000, 5000, 2000], "pe": [2000, 5000, 10000]})
+            >>> df.select(options.oi_zones("k", "ce", "pe", 1).alias("z"))["z"][0]["resistance_strikes"]
+            [24800.0]
         """
         exprs: list[pl.Expr] = []
         s_name = options._handle_arg(exprs, strikes_col, "_s_col")
@@ -392,33 +402,30 @@ class options:
 
     @staticmethod
     def gex_per_strike(
-        spot_col_or_val,
-        strikes_col,
-        ce_gamma_col,
-        pe_gamma_col,
-        ce_oi_col,
-        pe_oi_col,
-        lot_size_col_or_val,
-    ):
+        spot_col_or_val: _ColOrVal,
+        strikes_col: _Col,
+        ce_gamma_col: _Col,
+        pe_gamma_col: _Col,
+        ce_oi_col: _Col,
+        pe_oi_col: _Col,
+        lot_size_col_or_val: _ColOrVal,
+    ) -> pl.Expr:
         """Per-strike Gamma Exposure (native Polars expression).
 
         CE GEX = CE_OI * CE_gamma * spot * lot * 0.01; PE GEX uses -0.01; the
         struct also carries net_gex = CE + PE. Mirrors ``chain_analytics::
         gex_per_strike`` exactly, with no per-row FFI.
 
-        Returns
-        -------
-        pl.Expr
-            Struct{ce_gex: f64, pe_gex: f64, net_gex: f64} (same length as input).
+        Returns:
+            pl.Expr: Struct{ce_gex: f64, pe_gex: f64, net_gex: f64} (same length as input).
 
-        Examples
-        --------
-        >>> import polars as pl
-        >>> from quantwave.polars import options
-        >>> df = pl.DataFrame({"k": [25000.0], "cg": [0.0005], "pg": [0.0005],
-        ...                    "ce": [4000], "pe": [5000]})
-        >>> df.select(options.gex_per_strike(25000.0, "k", "cg", "pg", "ce", "pe", 50)
-        ...          )["k"][0]["net_gex"]  # doctest: +SKIP
+        Examples:
+            >>> import polars as pl
+            >>> from quantwave.polars import options
+            >>> df = pl.DataFrame({"k": [25000.0], "cg": [0.0005], "pg": [0.0005],
+            ...                    "ce": [4000], "pe": [5000]})
+            >>> df.select(options.gex_per_strike(25000.0, "k", "cg", "pg", "ce", "pe", 50)
+            ...          )["k"][0]["net_gex"]  # doctest: +SKIP
         """
         spot = _as_expr(spot_col_or_val)
         lot = _as_expr(lot_size_col_or_val)
@@ -431,19 +438,18 @@ class options:
         )
 
     @staticmethod
-    def gex_flip_strike(strikes_col, net_gex_col):
+    def gex_flip_strike(strikes_col: _Col, net_gex_col: _Col) -> pl.Expr:
         """Strike where cumulative Net GEX first changes sign (whole-chain reduction).
 
         Single native Rust call (``chain_analytics::gex_flip_strike``); returns a
         length-1 Float64 (null if no sign change). Apply per expiry snapshot.
 
-        Examples
-        --------
-        >>> import polars as pl
-        >>> from quantwave.polars import options
-        >>> df = pl.DataFrame({"k": [24800.0, 25000.0], "gex": [4.0, -0.5]})
-        >>> df.select(options.gex_flip_strike("k", "gex").alias("x"))["x"][0]
-        24800.0
+        Examples:
+            >>> import polars as pl
+            >>> from quantwave.polars import options
+            >>> df = pl.DataFrame({"k": [24800.0, 25000.0], "gex": [4.0, -0.5]})
+            >>> df.select(options.gex_flip_strike("k", "gex").alias("x"))["x"][0]
+            24800.0
         """
         exprs: list[pl.Expr] = []
         s_name = options._handle_arg(exprs, strikes_col, "_s_col")
@@ -460,26 +466,28 @@ class options:
         return pl.struct(exprs).map_batches(_flip, return_dtype=pl.Float64)
 
     @staticmethod
-    def atm_straddle(spot_col_or_val, strikes_col, ce_ltp_col, pe_ltp_col):
+    def atm_straddle(
+        spot_col_or_val: _ColOrVal,
+        strikes_col: _Col,
+        ce_ltp_col: _Col,
+        pe_ltp_col: _Col,
+    ) -> pl.Expr:
         """ATM straddle analytics for one chain (whole-chain reduction).
 
         Finds the strike closest to spot and returns its straddle premium and
         implied move. Single native Rust call (``chain_analytics::atm_straddle``);
         returns a length-1 struct. Apply per expiry snapshot.
 
-        Returns
-        -------
-        pl.Expr
-            Struct{atm_strike: f64, straddle_premium: f64, implied_move_pct: f64}.
+        Returns:
+            pl.Expr: Struct{atm_strike: f64, straddle_premium: f64, implied_move_pct: f64}.
 
-        Examples
-        --------
-        >>> import polars as pl
-        >>> from quantwave.polars import options
-        >>> df = pl.DataFrame({"k": [24800.0, 25000.0], "ce": [250.0, 100.0],
-        ...                    "pe": [10.0, 60.0]})
-        >>> df.select(options.atm_straddle(25000.0, "k", "ce", "pe").alias("s"))["s"][0]["atm_strike"]
-        25000.0
+        Examples:
+            >>> import polars as pl
+            >>> from quantwave.polars import options
+            >>> df = pl.DataFrame({"k": [24800.0, 25000.0], "ce": [250.0, 100.0],
+            ...                    "pe": [10.0, 60.0]})
+            >>> df.select(options.atm_straddle(25000.0, "k", "ce", "pe").alias("s"))["s"][0]["atm_strike"]
+            25000.0
         """
         exprs: list[pl.Expr] = []
         sp_name = options._handle_arg(exprs, spot_col_or_val, "_sp_val")
@@ -511,19 +519,18 @@ class options:
         )
 
     @staticmethod
-    def moneyness(spot, strike_col):
+    def moneyness(spot: float, strike_col: _Col) -> pl.Expr:
         """Per-strike moneyness (ITM/ATM/OTM) from a call perspective, native expression.
 
         ATM band is spot +/- 0.2% (mirrors ``options_india::india::moneyness``):
         strike < spot*0.998 -> ITM, strike > spot*1.002 -> OTM, else ATM.
 
-        Examples
-        --------
-        >>> import polars as pl
-        >>> from quantwave.polars import options
-        >>> df = pl.DataFrame({"k": [24800.0, 25000.0, 25200.0]})
-        >>> df.select(options.moneyness(25000.0, "k").alias("x"))["x"].to_list()
-        ['ITM', 'ATM', 'OTM']
+        Examples:
+            >>> import polars as pl
+            >>> from quantwave.polars import options
+            >>> df = pl.DataFrame({"k": [24800.0, 25000.0, 25200.0]})
+            >>> df.select(options.moneyness(25000.0, "k").alias("x"))["x"].to_list()
+            ['ITM', 'ATM', 'OTM']
         """
         strike = _as_expr(strike_col)
         return (
@@ -535,19 +542,18 @@ class options:
         )
 
     @staticmethod
-    def nse_lot_size(symbol_col):
+    def nse_lot_size(symbol_col: _Col) -> pl.Expr:
         """Map an NSE index symbol column to its lot size (native expression).
 
         Mirrors ``options_india::india::nse_lot_size``; unknown symbols map to
         null. Case-insensitive.
 
-        Examples
-        --------
-        >>> import polars as pl
-        >>> from quantwave.polars import options
-        >>> df = pl.DataFrame({"sym": ["NIFTY", "BANKNIFTY"]})
-        >>> df.select(options.nse_lot_size("sym").alias("x"))["x"].to_list()
-        [50, 15]
+        Examples:
+            >>> import polars as pl
+            >>> from quantwave.polars import options
+            >>> df = pl.DataFrame({"sym": ["NIFTY", "BANKNIFTY"]})
+            >>> df.select(options.nse_lot_size("sym").alias("x"))["x"].to_list()
+            [50, 15]
         """
         return (
             _as_expr(symbol_col)


### PR DESCRIPTION
Closes the substantive remainder of **quantwave-5ipk.5**.

## Fixes
- **`/reference/` and `/backtest/` 404s** (review-flagged) → redirect stubs matching the existing native-page meta-refresh pattern (`/reference/` → `/api/`, `/backtest/` → `/guides/backtest/`).
- **8 `mkdocs_autorefs` warnings → 0**: `quantwave/polars.py` used NumPy-style docstrings while mkdocstrings is configured `docstring_style: google` (as every other module uses), so its doctest output (`[0]`, `[24800.0]`) was misread as cross-references. Converted to Google style.
- **Typed options API**: added `_Col`/`_ColOrVal` aliases and `-> pl.Expr` returns to all `options` methods, clearing the griffe "no annotation" warnings and giving the flagship Options India surface full type coverage.

## Verification
- `mkdocs build --strict` → **0 autorefs, 0 link warnings**
- doctests (11) + `tests/options_india` (42) pass
- `check_doc_links` / `check_doc_latex` / `check_doc_drift` all green

## Deferred (cosmetic, documented on the bead)
Migrating the 162 native redirect stubs to `mkdocs-redirects` — that plugin also emits meta-refresh HTML (no functional gain) and would require the `sync_indicator_docs.py` generator to programmatically rewrite `mkdocs.yml`. Not worth the risk; the stubs work and are generator-maintained.

Docstring conversion + annotations done by a Sonnet subagent; orchestration + redirects + verification by the main agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)