### PR TITLE
chore(release): 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "quantwave"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "quantwave-core",
  "quantwave-polars",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "quantwave-backtest"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "approx",
  "chrono",
@@ -1894,7 +1894,7 @@ dependencies = [
 
 [[package]]
 name = "quantwave-core"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "approx",
  "chrono",
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "quantwave-polars"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "approx",
  "polars",
@@ -1925,7 +1925,7 @@ dependencies = [
 
 [[package]]
 name = "quantwave-py"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "paste",
  "polars",
@@ -1941,7 +1941,7 @@ dependencies = [
 
 [[package]]
 name = "quantwave-xtask"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/lavs9/quantwave"
@@ -38,9 +38,9 @@ thiserror = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 nalgebra = { version = "0.33", features = ["serde-serialize"] }
 statrs = "0.18"
-quantwave-core = { path = "quantwave-core", version = "0.6.1" }
-quantwave-polars = { path = "quantwave-polars", version = "0.6.1" }
-quantwave-backtest = { path = "quantwave-backtest", version = "0.6.1" }
+quantwave-core = { path = "quantwave-core", version = "0.7.0" }
+quantwave-polars = { path = "quantwave-polars", version = "0.7.0" }
+quantwave-backtest = { path = "quantwave-backtest", version = "0.7.0" }
 
 [profile.dev]
 opt-level = 0

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.7.0] - 2026-07-13
+
+### Added
+- **Complete classic TA-Lib surface** (`quantwave.talib`): **161** functions, up from 8 — RSI, MACD, SMA, EMA, ATR, ADX, BBANDS, STOCH, OBV, all 61 candlestick patterns, and the math/price transforms. The classic array-in/array-out API (`talib.RSI(close, timeperiod=14)`, multi-output tuples, OHLC/candlestick inputs) delegates to the Polars `.ta` plugins, so values are the talib-rs-parity-tested Rust results. (`quantwave-yp9a`)
+- Top-level native symbol access restored: `qw.FracDiff`, `qw.fracdiff`, `qw.rsi`, `qw.SuperTrend`, … bind alongside the slug-based `qw.ta` namespace.
+
+### Changed
+- **Unified the Python FFI on PyO3 (abi3), retiring uniffi.** The indicator bindings, the Polars expression plugins, and the backtest engine are now a **single** PyO3 `abi3-py39` extension in one crate (`quantwave-py`) producing one cdylib — a single `maturin build` yields one `cp39-abi3` wheel with no wheel-merge step. (`quantwave-5ipk.10`, `quantwave-6dgg`)
+- Collapsed the three PyO3 crates (`quantwave-python`, `quantwave-plugins`, `quantwave-backtest-py`) into `quantwave-py`; deleted `scripts/build_unified_wheel.py` and consolidated to one `pyproject.toml`.
+
+### Fixed
+- **Wheel tag / install correctness**: the published wheel is now `cp39-abi3` and installs correctly on **CPython 3.9–3.13**. 0.6.1 shipped a `py3-none` wheel bundling CPython-3.12-only extensions, which broke `pip install` on 3.9/3.10/3.11/3.13. (`quantwave-9gek.1`)
+
 ## [0.6.0] - 2026-06-28
 
 ### Added


### PR DESCRIPTION
Release prep for **v0.7.0**: version bump (`0.6.1 → 0.7.0`) + changelog.

## Highlights since 0.6.1
- **FFI unified on PyO3 abi3** (retired uniffi); three PyO3 crates collapsed into one `quantwave-py` cdylib; a single `maturin build` produces one `cp39-abi3` wheel (no wheel-merge). (5ipk.10, 6dgg)
- **Wheel-tag fix** — installs correctly on CPython **3.9–3.13** (0.6.1 shipped a `py3-none` wheel that broke 3.9/3.10/3.11/3.13). (9gek.1)
- **Complete classic TA-Lib surface** — `quantwave.talib` now exposes **161** functions (was 8), delegating to the talib-rs-parity-tested Polars `.ta` plugins. (yp9a)

After merge + green CI on `main`, tag `v0.7.0` triggers `release.yml` → crates.io + PyPI (OIDC) + install smoke on 3.9/3.11/3.12/3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)