### PR TITLE
fix(py39): restore Python 3.9 import + optional numpy (v0.7.0 release hotfix)

### DIFF
--- a/quantwave-py/python/quantwave/__init__.py
+++ b/quantwave-py/python/quantwave/__init__.py
@@ -33,6 +33,8 @@ Exception contract (``quantwave.QuantwaveError`` hierarchy):
 ``StreamingError``, and ``InternalError`` (native FFI). See ``quantwave._errors``.
 """
 
+from __future__ import annotations  # PEP 604 (str | None) annotations on Python 3.9
+
 from typing import List, Dict, Any
 import warnings
 

--- a/quantwave-py/python/quantwave/talib.py
+++ b/quantwave-py/python/quantwave/talib.py
@@ -25,9 +25,11 @@ from __future__ import annotations
 import inspect
 from typing import Any, Callable, Dict, List, Optional
 
-import numpy as np
-
 from quantwave._talib_map_generated import TALIB_SLUG_TO_NAME as _TALIB_MAP
+
+# numpy is imported lazily (inside the wrappers) so that `import quantwave` — and the
+# rest of quantwave.talib's discovery API (list_functions) — work without numpy
+# installed. Calling a talib function does require numpy (classic array in/out).
 
 # Canonical TA-Lib price-input order. Multi-input functions receive their arrays in
 # this order (subset), matching classic talib (e.g. ATR(high, low, close)).
@@ -148,6 +150,8 @@ def _make_wrapper(talib_name: str, method_name: str) -> Callable[..., Any]:
     spec = _Signature(method_name)
 
     def wrapper(*arrays, **kwargs):
+        import numpy as np  # lazy: classic talib API is numpy-based
+
         if len(arrays) != len(spec.input_roles):
             raise TypeError(
                 f"{talib_name} expects {len(spec.input_roles)} input array(s) "


### PR DESCRIPTION
**Release recovery for v0.7.0.** The tag's wheel-smoke failed on **CPython 3.9**:

```
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
  quantwave/__init__.py:205  def __init__(self, slug: str, polars_method: str | None)
```

`__init__.py` used a runtime PEP 604 union (`str | None`) without `from __future__ import annotations` — PEP 604 at runtime is 3.10+. Fix: add the future import (all annotations become lazy strings). Also make `numpy` lazy in `quantwave.talib` so `import quantwave` / `list_functions()` work without numpy.

**State:** crates.io already published 0.7.0 (Rust job ✓); PyPI did **not** (gated on smoke). After merge I'll re-tag `v0.7.0` on the fixed commit — `publish_crates.sh` is idempotent (skips already-published crates), so the rebuilt wheel publishes to PyPI cleanly.

**Verified on Python 3.9.19:** `wheel_smoke_test` passes without numpy; `talib.RSI` works with numpy; `talib.list_functions()`=161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)