### PR TITLE
fix(python): constructable GaussianHmmParamsPy + dict-like backtest metrics (nhkk)

### DIFF
--- a/quantwave-py/python/quantwave/backtest_types.py
+++ b/quantwave-py/python/quantwave/backtest_types.py
@@ -28,9 +28,17 @@ class PerformanceMetrics:
         
     def keys(self):
         return self.as_dict().keys()
-        
+
     def __getitem__(self, key: str):
         return getattr(self, key)
+
+    def __contains__(self, key: object) -> bool:
+        # Without this, ``"x" in metrics`` falls back to integer-index iteration
+        # via __getitem__ (getattr(self, 0)) and raises TypeError.
+        return isinstance(key, str) and key in self.as_dict()
+
+    def __iter__(self):
+        return iter(self.keys())
 
 @dataclass(frozen=True)
 class BacktestStats:
@@ -50,6 +58,12 @@ class BacktestStats:
         
     def keys(self):
         return self.as_dict().keys()
-        
+
     def __getitem__(self, key: str):
         return getattr(self, key)
+
+    def __contains__(self, key: object) -> bool:
+        return isinstance(key, str) and key in self.as_dict()
+
+    def __iter__(self):
+        return iter(self.keys())

--- a/quantwave-py/src/indicators.rs
+++ b/quantwave-py/src/indicators.rs
@@ -1883,6 +1883,30 @@ pub struct GaussianHmmParamsPy {
     /// Per-state λ (empty → 1.0 per state, Gaussian mode).
     pub lambdas: Vec<f64>,
 }
+#[pymethods]
+impl GaussianHmmParamsPy {
+    // Constructable from Python (input params, not a read-only result record):
+    // `qw.GaussianHmmParamsPy(n_states, delta, gamma_flat, means, stds, lambdas=[])`.
+    #[new]
+    #[pyo3(signature = (n_states, delta, gamma_flat, means, stds, lambdas = Vec::new()))]
+    pub fn new(
+        n_states: u32,
+        delta: Vec<f64>,
+        gamma_flat: Vec<f64>,
+        means: Vec<f64>,
+        stds: Vec<f64>,
+        lambdas: Vec<f64>,
+    ) -> Self {
+        Self {
+            n_states,
+            delta,
+            gamma_flat,
+            means,
+            stds,
+            lambdas,
+        }
+    }
+}
 
 #[pyclass(get_all)]
 #[derive(Clone)]


### PR DESCRIPTION
Two `uniffi → PyO3` record-port gaps, surfaced when the previously-CI-invisible tests were relocated to `tests/python/` (both confirmed pre-existing on `main`, not regressions from the FFI work):

1. **`GaussianHmmParamsPy` had no `#[new]`.** It's an *input* params record Python constructs (`qw.GaussianHmmParamsPy(n_states=…, delta=…, …)`), but the ported `#[pyclass(get_all)]` wasn't constructable → *"No constructor defined"*. Added `#[new]` (`lambdas` defaults to empty = Gaussian mode). **Audited all 49 records** — this is the only one Python constructs; the rest are read-only outputs.
2. **`PerformanceMetrics` / `BacktestStats` broke the `in` operator.** They had `__getitem__(str)` + `keys()` but no `__contains__`, so `"sharpe_ratio" in metrics` fell back to integer-index iteration → `TypeError: attribute name must be string, not 'int'`. Added `__contains__` + `__iter__` (now properly dict-like).

**Result:** fixes `test_hmm_forecast` (2), `test_ml_feature_backtest_parity`, `test_strategy_backtest`. Full suite **6 → 2** failures; the remaining two are unrelated — a `pandas`-only benchmark test and a stale `LazyFrame.ta` `test_parity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)