### PR TITLE
fix(py): restore 68 batch indicators silently degraded to streaming classes (84cu)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **68 indicators silently resolved to a streaming class instead of their batch function** (`quantwave-84cu`). The generated TA registry introduced in 0.7.0 derived native batch symbol names with `pascal_to_snake()` (`SuperTrend` → `super_trend`), but the `export_*!` macros emit `pub fn [<$name:lower>]` (`SuperTrend` → `supertrend`). Every multi-word name missed; the 44 single-word ones (`rsi`, `sma`, `atr`) passed only because `pascal_to_snake("Rsi") == "rsi"`. `_resolve_ta_binding` treated the miss as a fallback and returned `native_streaming`, so `qw.supertrend` was a **class** while `qw.rsi` was a function — with no error or warning. `qw.supertrend(period=10, multiplier=3.0, high=…, low=…, close=…)` again returns `list[SuperTrendResult]` as it did in 0.6; callers need no changes.
+- `_resolve_ta_binding` now raises `ImportError` when an entry declares a `native_batch` symbol the build does not export, rather than silently substituting the streaming class (whose calling convention differs). A `native_batch` of `None` still falls through to streaming/polars as before.
+- Corrected stale hand-written aliases in `scripts/api_slug_aliases.json`: `fm_demodulator`, `fourier_series_model`, `my_rsi`, `precision_trend_analysis` named non-existent snake_cased symbols; `linreg`, `oc2`, `true_range` declared batch exports that do not exist and now fall through to their polars methods; `sr_monitor` declared `SrInteractionMonitor`, a class never exported to Python.
+
+### Added
+- `test_registry_native_symbols_resolve_against_build` — asserts every declared native symbol exists in the compiled module. The prior test only checked a name was *present*, never that it *resolved*, so `native_batch: "super_trend"` passed cleanly. Plus a regression test that multi-word slugs bind as batch functions, not classes.
+
 ## [0.7.0] - 2026-07-13
 
 ### Added

--- a/quantwave-py/python/quantwave/__init__.py
+++ b/quantwave-py/python/quantwave/__init__.py
@@ -225,10 +225,20 @@ def _bind_ta(slug: str, obj) -> None:
 
 
 def _resolve_ta_binding(slug: str, entry: dict) -> object:
-    for key in ("native_batch", "native_streaming"):
-        native_name = entry.get(key)
-        if native_name and hasattr(_quantwave, native_name):
-            return getattr(_quantwave, native_name)
+    native_batch = entry.get("native_batch")
+    if native_batch:
+        if not hasattr(_quantwave, native_batch):
+            raise ImportError(
+                f"TA registry entry {slug!r} declares native_batch={native_batch!r}, "
+                f"but the compiled module exports no such symbol. The registry is stale "
+                f"— regenerate it with scripts/generate_api_stubs.py. (Falling back to "
+                f"the streaming class here would silently change {slug!r}'s calling "
+                f"convention from a batch function to a class.)"
+            )
+        return getattr(_quantwave, native_batch)
+    native_streaming = entry.get("native_streaming")
+    if native_streaming and hasattr(_quantwave, native_streaming):
+        return getattr(_quantwave, native_streaming)
     polars_method = entry.get("polars_method")
     if polars_method:
         return _PolarsOnlySurface(slug, polars_method)

--- a/quantwave-py/python/quantwave/_ta_registry_generated.py
+++ b/quantwave-py/python/quantwave/_ta_registry_generated.py
@@ -504,19 +504,19 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "channel_cycle": {
         "slug": "channel_cycle",
         "polars_method": None,
-        "native_batch": "channel_cycle",
+        "native_batch": "channelcycle",
         "native_streaming": "ChannelCycle",
     },
     "choppiness_index": {
         "slug": "choppiness_index",
         "polars_method": None,
-        "native_batch": "choppiness_index",
+        "native_batch": "choppinessindex",
         "native_streaming": "ChoppinessIndex",
     },
     "classic_laguerre": {
         "slug": "classic_laguerre",
         "polars_method": None,
-        "native_batch": "classic_laguerre",
+        "native_batch": "classiclaguerre",
         "native_streaming": "ClassicLaguerre",
     },
     "cmo": {
@@ -528,7 +528,7 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "continuation_index": {
         "slug": "continuation_index",
         "polars_method": None,
-        "native_batch": "continuation_index",
+        "native_batch": "continuationindex",
         "native_streaming": "ContinuationIndex",
     },
     "correl": {
@@ -540,25 +540,25 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "correlation_cycle": {
         "slug": "correlation_cycle",
         "polars_method": None,
-        "native_batch": "correlation_cycle",
+        "native_batch": "correlationcycle",
         "native_streaming": "CorrelationCycle",
     },
     "correlation_trend": {
         "slug": "correlation_trend",
         "polars_method": None,
-        "native_batch": "correlation_trend",
+        "native_batch": "correlationtrend",
         "native_streaming": "CorrelationTrend",
     },
     "cyber_cycle": {
         "slug": "cyber_cycle",
         "polars_method": None,
-        "native_batch": "cyber_cycle",
+        "native_batch": "cybercycle",
         "native_streaming": "CyberCycle",
     },
     "cybernetic_oscillator": {
         "slug": "cybernetic_oscillator",
         "polars_method": None,
-        "native_batch": "cybernetic_oscillator",
+        "native_batch": "cyberneticoscillator",
         "native_streaming": "CyberneticOscillator",
     },
     "cycle_trend_analytics": {
@@ -594,31 +594,31 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "ehlers_autocorrelation": {
         "slug": "ehlers_autocorrelation",
         "polars_method": None,
-        "native_batch": "ehlers_autocorrelation",
+        "native_batch": "ehlersautocorrelation",
         "native_streaming": "EhlersAutocorrelation",
     },
     "ehlers_filter": {
         "slug": "ehlers_filter",
         "polars_method": None,
-        "native_batch": "ehlers_filter",
+        "native_batch": "ehlersfilter",
         "native_streaming": "EhlersFilter",
     },
     "ehlers_loops": {
         "slug": "ehlers_loops",
         "polars_method": None,
-        "native_batch": "ehlers_loops",
+        "native_batch": "ehlersloops",
         "native_streaming": "EhlersLoops",
     },
     "ehlers_stochastic": {
         "slug": "ehlers_stochastic",
         "polars_method": None,
-        "native_batch": "ehlers_stochastic",
+        "native_batch": "ehlersstochastic",
         "native_streaming": "EhlersStochastic",
     },
     "ehlers_ultimate_oscillator": {
         "slug": "ehlers_ultimate_oscillator",
         "polars_method": None,
-        "native_batch": "ehlers_ultimate_oscillator",
+        "native_batch": "ehlersultimateoscillator",
         "native_streaming": "EhlersUltimateOscillator",
     },
     "ema": {
@@ -642,31 +642,31 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "fisher_high_pass": {
         "slug": "fisher_high_pass",
         "polars_method": None,
-        "native_batch": "fisher_high_pass",
+        "native_batch": "fisherhighpass",
         "native_streaming": "FisherHighPass",
     },
     "fm_demodulator": {
         "slug": "fm_demodulator",
         "polars_method": None,
-        "native_batch": "fm_demodulator",
+        "native_batch": "fmdemodulator",
         "native_streaming": "FmDemodulator",
     },
     "fourier_dominant_cycle": {
         "slug": "fourier_dominant_cycle",
         "polars_method": None,
-        "native_batch": "fourier_dominant_cycle",
+        "native_batch": "fourierdominantcycle",
         "native_streaming": "FourierDominantCycle",
     },
     "fourier_series_model": {
         "slug": "fourier_series_model",
         "polars_method": None,
-        "native_batch": "fourier_series",
+        "native_batch": "fourierseries",
         "native_streaming": "FourierSeries",
     },
     "frac_diff": {
         "slug": "frac_diff",
         "polars_method": None,
-        "native_batch": "frac_diff",
+        "native_batch": "fracdiff",
         "native_streaming": "FracDiff",
     },
     "fractals": {
@@ -702,7 +702,7 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "generalized_laguerre": {
         "slug": "generalized_laguerre",
         "polars_method": None,
-        "native_batch": "generalized_laguerre",
+        "native_batch": "generalizedlaguerre",
         "native_streaming": "GeneralizedLaguerre",
     },
     "geometric_patterns": {
@@ -714,19 +714,19 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "griffiths_dominant_cycle": {
         "slug": "griffiths_dominant_cycle",
         "polars_method": None,
-        "native_batch": "griffiths_dominant_cycle",
+        "native_batch": "griffithsdominantcycle",
         "native_streaming": "GriffithsDominantCycle",
     },
     "griffiths_predictor": {
         "slug": "griffiths_predictor",
         "polars_method": None,
-        "native_batch": "griffiths_predictor",
+        "native_batch": "griffithspredictor",
         "native_streaming": "GriffithsPredictor",
     },
     "griffiths_spectrum": {
         "slug": "griffiths_spectrum",
         "polars_method": None,
-        "native_batch": "griffiths_spectrum",
+        "native_batch": "griffithsspectrum",
         "native_streaming": "GriffithsSpectrum",
     },
     "hamming_filter": {
@@ -756,7 +756,7 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "high_pass": {
         "slug": "high_pass",
         "polars_method": None,
-        "native_batch": "high_pass",
+        "native_batch": "highpass",
         "native_streaming": "HighPass",
     },
     "hma": {
@@ -774,43 +774,43 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "homodyne_discriminator": {
         "slug": "homodyne_discriminator",
         "polars_method": None,
-        "native_batch": "homodyne_discriminator",
+        "native_batch": "homodynediscriminator",
         "native_streaming": "HomodyneDiscriminator",
     },
     "ht_dcperiod": {
         "slug": "ht_dcperiod",
         "polars_method": "ht_dcperiod",
-        "native_batch": "ht_dc_period",
+        "native_batch": "htdcperiod",
         "native_streaming": "HtDcPeriod",
     },
     "ht_dcphase": {
         "slug": "ht_dcphase",
         "polars_method": "ht_dcphase",
-        "native_batch": "ht_dc_phase",
+        "native_batch": "htdcphase",
         "native_streaming": "HtDcPhase",
     },
     "ht_phasor": {
         "slug": "ht_phasor",
         "polars_method": "ht_phasor",
-        "native_batch": "ht_phasor",
+        "native_batch": "htphasor",
         "native_streaming": "HtPhasor",
     },
     "ht_sine": {
         "slug": "ht_sine",
         "polars_method": "ht_sine",
-        "native_batch": "ht_sine",
+        "native_batch": "htsine",
         "native_streaming": "HtSine",
     },
     "ht_trendmode": {
         "slug": "ht_trendmode",
         "polars_method": "ht_trendmode",
-        "native_batch": "ht_trend_mode",
+        "native_batch": "httrendmode",
         "native_streaming": "HtTrendMode",
     },
     "hurst_exponent": {
         "slug": "hurst_exponent",
         "polars_method": None,
-        "native_batch": "hurst_exponent",
+        "native_batch": "hurstexponent",
         "native_streaming": "HurstExponent",
     },
     "ichimoku": {
@@ -822,19 +822,19 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "instantaneous_trendline": {
         "slug": "instantaneous_trendline",
         "polars_method": None,
-        "native_batch": "instantaneous_trendline",
+        "native_batch": "instantaneoustrendline",
         "native_streaming": "InstantaneousTrendline",
     },
     "inverse_fisher": {
         "slug": "inverse_fisher",
         "polars_method": None,
-        "native_batch": "inverse_fisher",
+        "native_batch": "inversefisher",
         "native_streaming": "InverseFisher",
     },
     "kalman_filter": {
         "slug": "kalman_filter",
         "polars_method": None,
-        "native_batch": "kalman_filter",
+        "native_batch": "kalmanfilter",
         "native_streaming": "KalmanFilter",
     },
     "kama": {
@@ -858,19 +858,19 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "laguerre_filter": {
         "slug": "laguerre_filter",
         "polars_method": None,
-        "native_batch": "laguerre_filter",
+        "native_batch": "laguerrefilter",
         "native_streaming": "LaguerreFilter",
     },
     "laguerre_oscillator": {
         "slug": "laguerre_oscillator",
         "polars_method": None,
-        "native_batch": "laguerre_oscillator",
+        "native_batch": "laguerreoscillator",
         "native_streaming": "LaguerreOscillator",
     },
     "laguerre_rsi": {
         "slug": "laguerre_rsi",
         "polars_method": None,
-        "native_batch": "laguerre_rsi",
+        "native_batch": "laguerrersi",
         "native_streaming": "LaguerreRsi",
     },
     "lambda_hmm": {
@@ -882,7 +882,7 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "linreg": {
         "slug": "linreg",
         "polars_method": "linearreg",
-        "native_batch": "linearreg",
+        "native_batch": None,
         "native_streaming": None,
     },
     "macd": {
@@ -912,7 +912,7 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "market_state": {
         "slug": "market_state",
         "polars_method": None,
-        "native_batch": "market_state",
+        "native_batch": "marketstate",
         "native_streaming": "MarketState",
     },
     "market_structure": {
@@ -930,7 +930,7 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "mesa_stochastic": {
         "slug": "mesa_stochastic",
         "polars_method": None,
-        "native_batch": "mesa_stochastic",
+        "native_batch": "mesastochastic",
         "native_streaming": "MesaStochastic",
     },
     "mfi": {
@@ -948,7 +948,7 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "my_rsi": {
         "slug": "my_rsi",
         "polars_method": None,
-        "native_batch": "oc_price_rsi",
+        "native_batch": "ocpricersi",
         "native_streaming": "OcPriceRsi",
     },
     "natr": {
@@ -960,7 +960,7 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "noise_elimination": {
         "slug": "noise_elimination",
         "polars_method": None,
-        "native_batch": "noise_elimination",
+        "native_batch": "noiseelimination",
         "native_streaming": "NoiseElimination",
     },
     "obv": {
@@ -972,25 +972,25 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "oc2": {
         "slug": "oc2",
         "polars_method": "avgprice",
-        "native_batch": "avgprice",
+        "native_batch": None,
         "native_streaming": None,
     },
     "oc_price_rsi": {
         "slug": "oc_price_rsi",
         "polars_method": None,
-        "native_batch": "oc_price_rsi",
+        "native_batch": "ocpricersi",
         "native_streaming": "OcPriceRsi",
     },
     "one_euro_filter": {
         "slug": "one_euro_filter",
         "polars_method": None,
-        "native_batch": "one_euro_filter",
+        "native_batch": "oneeurofilter",
         "native_streaming": "OneEuroFilter",
     },
     "pairs_rotation": {
         "slug": "pairs_rotation",
         "polars_method": None,
-        "native_batch": "pairs_rotation",
+        "native_batch": "pairsrotation",
         "native_streaming": "PairsRotation",
     },
     "phasor": {
@@ -1014,25 +1014,25 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "precision_trend_analysis": {
         "slug": "precision_trend_analysis",
         "polars_method": None,
-        "native_batch": "precision_trend",
+        "native_batch": "precisiontrend",
         "native_streaming": "PrecisionTrend",
     },
     "projected_moving_average": {
         "slug": "projected_moving_average",
         "polars_method": None,
-        "native_batch": "projected_moving_average",
+        "native_batch": "projectedmovingaverage",
         "native_streaming": "ProjectedMovingAverage",
     },
     "recursive_median": {
         "slug": "recursive_median",
         "polars_method": None,
-        "native_batch": "recursive_median",
+        "native_batch": "recursivemedian",
         "native_streaming": "RecursiveMedian",
     },
     "recursive_median_oscillator": {
         "slug": "recursive_median_oscillator",
         "polars_method": None,
-        "native_batch": "recursive_median_oscillator",
+        "native_batch": "recursivemedianoscillator",
         "native_streaming": "RecursiveMedianOscillator",
     },
     "reflex": {
@@ -1050,7 +1050,7 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "reversion_index": {
         "slug": "reversion_index",
         "polars_method": None,
-        "native_batch": "reversion_index",
+        "native_batch": "reversionindex",
         "native_streaming": "ReversionIndex",
     },
     "roc": {
@@ -1062,13 +1062,13 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "rocket_rsi": {
         "slug": "rocket_rsi",
         "polars_method": None,
-        "native_batch": "rocket_rsi",
+        "native_batch": "rocketrsi",
         "native_streaming": "RocketRsi",
     },
     "roofing_filter": {
         "slug": "roofing_filter",
         "polars_method": None,
-        "native_batch": "roofing_filter",
+        "native_batch": "roofingfilter",
         "native_streaming": "RoofingFilter",
     },
     "rsi": {
@@ -1098,13 +1098,13 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "simple_predictor": {
         "slug": "simple_predictor",
         "polars_method": None,
-        "native_batch": "simple_predictor",
+        "native_batch": "simplepredictor",
         "native_streaming": "SimplePredictor",
     },
     "sine_wave": {
         "slug": "sine_wave",
         "polars_method": None,
-        "native_batch": "sine_wave",
+        "native_batch": "sinewave",
         "native_streaming": "SineWave",
     },
     "sma": {
@@ -1117,7 +1117,7 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
         "slug": "sr_monitor",
         "polars_method": "sr_interaction_monitor",
         "native_batch": None,
-        "native_streaming": "SrInteractionMonitor",
+        "native_streaming": None,
     },
     "stc": {
         "slug": "stc",
@@ -1140,13 +1140,13 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "super_smoother": {
         "slug": "super_smoother",
         "polars_method": None,
-        "native_batch": "super_smoother",
+        "native_batch": "supersmoother",
         "native_streaming": "SuperSmoother",
     },
     "supertrend": {
         "slug": "supertrend",
         "polars_method": "supertrend",
-        "native_batch": "super_trend",
+        "native_batch": "supertrend",
         "native_streaming": "SuperTrend",
     },
     "swiss_army_knife": {
@@ -1158,13 +1158,13 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "synthetic_oscillator": {
         "slug": "synthetic_oscillator",
         "polars_method": None,
-        "native_batch": "synthetic_oscillator",
+        "native_batch": "syntheticoscillator",
         "native_streaming": "SyntheticOscillator",
     },
     "system_evaluator": {
         "slug": "system_evaluator",
         "polars_method": None,
-        "native_batch": "system_evaluator",
+        "native_batch": "systemevaluator",
         "native_streaming": "SystemEvaluator",
     },
     "t3": {
@@ -1194,7 +1194,7 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "triangle_filter": {
         "slug": "triangle_filter",
         "polars_method": None,
-        "native_batch": "triangle_filter",
+        "native_batch": "trianglefilter",
         "native_streaming": "TriangleFilter",
     },
     "trima": {
@@ -1212,19 +1212,19 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "true_range": {
         "slug": "true_range",
         "polars_method": "trange",
-        "native_batch": "trange",
+        "native_batch": None,
         "native_streaming": None,
     },
     "truncated_bandpass": {
         "slug": "truncated_bandpass",
         "polars_method": None,
-        "native_batch": "truncated_bandpass",
+        "native_batch": "truncatedbandpass",
         "native_streaming": "TruncatedBandpass",
     },
     "ttm_squeeze": {
         "slug": "ttm_squeeze",
         "polars_method": "ttm_squeeze",
-        "native_batch": "ttm_squeeze",
+        "native_batch": "ttmsqueeze",
         "native_streaming": "TtmSqueeze",
     },
     "typprice": {
@@ -1248,7 +1248,7 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "ultimate_smoother": {
         "slug": "ultimate_smoother",
         "polars_method": None,
-        "native_batch": "ultimate_smoother",
+        "native_batch": "ultimatesmoother",
         "native_streaming": "UltimateSmoother",
     },
     "ultosc": {
@@ -1260,13 +1260,13 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "undersampled_double_ma": {
         "slug": "undersampled_double_ma",
         "polars_method": None,
-        "native_batch": "undersampled_double_ma",
+        "native_batch": "undersampleddoublema",
         "native_streaming": "UndersampledDoubleMa",
     },
     "universal_oscillator": {
         "slug": "universal_oscillator",
         "polars_method": None,
-        "native_batch": "universal_oscillator",
+        "native_batch": "universaloscillator",
         "native_streaming": "UniversalOscillator",
     },
     "usi": {
@@ -1290,7 +1290,7 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "voss_predictor": {
         "slug": "voss_predictor",
         "polars_method": None,
-        "native_batch": "voss_predictor",
+        "native_batch": "vosspredictor",
         "native_streaming": "VossPredictor",
     },
     "vpn": {
@@ -1308,7 +1308,7 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "wavetrend": {
         "slug": "wavetrend",
         "polars_method": "wavetrend",
-        "native_batch": "wave_trend",
+        "native_batch": "wavetrend",
         "native_streaming": "WaveTrend",
     },
     "wclprice": {
@@ -1332,7 +1332,7 @@ TA_REGISTRY: dict[str, TaRegistryEntry] = {
     "zero_lag": {
         "slug": "zero_lag",
         "polars_method": None,
-        "native_batch": "zero_lag",
+        "native_batch": "zerolag",
         "native_streaming": "ZeroLag",
     },
     "zlema": {

--- a/scripts/api_slug_aliases.json
+++ b/scripts/api_slug_aliases.json
@@ -8,7 +8,7 @@
   "sr_monitor": {
     "slug_alias": "sr_interaction_monitor",
     "polars_method": "sr_interaction_monitor",
-    "native_streaming": "SrInteractionMonitor"
+    "native_streaming": null
   },
   "gaussian_filter": {
     "native_batch": "gaussian",
@@ -24,30 +24,30 @@
     "native_streaming": "Hann"
   },
   "fourier_series_model": {
-    "native_batch": "fourier_series",
+    "native_batch": "fourierseries",
     "native_streaming": "FourierSeries"
   },
   "linreg": {
     "polars_method": "linearreg",
-    "native_batch": "linearreg"
+    "native_batch": null
   },
   "true_range": {
     "polars_method": "trange",
-    "native_batch": "trange"
+    "native_batch": null
   },
   "vwap": {
     "polars_method": "anchored_vwap"
   },
   "precision_trend_analysis": {
-    "native_batch": "precision_trend",
+    "native_batch": "precisiontrend",
     "native_streaming": "PrecisionTrend"
   },
   "oc2": {
     "polars_method": "avgprice",
-    "native_batch": "avgprice"
+    "native_batch": null
   },
   "my_rsi": {
-    "native_batch": "oc_price_rsi",
+    "native_batch": "ocpricersi",
     "native_streaming": "OcPriceRsi"
   },
   "am_detector": {
@@ -55,7 +55,7 @@
     "native_streaming": "AmDetector"
   },
   "fm_demodulator": {
-    "native_batch": "fm_demodulator",
+    "native_batch": "fmdemodulator",
     "native_streaming": "FmDemodulator"
   },
   "cdldoji": {

--- a/scripts/generate_api_stubs.py
+++ b/scripts/generate_api_stubs.py
@@ -114,7 +114,9 @@ def parse_native_symbols() -> tuple[set[str], set[str]]:
         name_attr = re.search(r'name\s*=\s*"([^"]+)"', attrs)
         streaming.add(name_attr.group(1) if name_attr else struct)
     for type_name in re.findall(r"export_[a-z0-9_]+!\s*\(\s*(\w+)", text):
-        batch.add(pascal_to_snake(type_name))
+        # uniffi's export_*! macros emit `pub fn [<$name:lower>]` — all-lowercase,
+        # no separators. pascal_to_snake would yield `super_trend`, which never exists.
+        batch.add(type_name.lower())
         streaming.add(type_name)
     return batch, streaming
 

--- a/tests/python/test_api_surface.py
+++ b/tests/python/test_api_surface.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import ast
+import inspect
 import re
 from pathlib import Path
+
+import pytest
 
 import quantwave as qw
 from quantwave._metadata_generated import GENERATED_ENTRIES
@@ -83,6 +86,26 @@ def test_registry_entries_have_surface_binding():
             or entry.get("native_streaming")
             or entry.get("polars_method")
         ), slug
+
+
+def test_registry_native_symbols_resolve_against_build():
+    """A declared native symbol must actually exist — a name alone proves nothing."""
+    import quantwave._quantwave as _q
+
+    missing = [
+        (slug, entry[key])
+        for slug, entry in TA_REGISTRY.items()
+        for key in ("native_batch", "native_streaming")
+        if entry.get(key) and not hasattr(_q, entry[key])
+    ]
+    assert missing == [], f"registry names absent from build: {missing}"
+
+
+@pytest.mark.parametrize("slug", ["supertrend", "wavetrend", "frac_diff", "cyber_cycle"])
+def test_multiword_indicators_are_batch_functions_not_classes(slug):
+    """Regression: pascal_to_snake once made every multi-word slug degrade to a class."""
+    obj = getattr(qw, slug)
+    assert not inspect.isclass(obj), f"qw.{slug} degraded to a streaming class"
 
 
 def test_streaming_class_uses_registry_for_rsi():


### PR DESCRIPTION
## Summary

`qw.supertrend` was a **class**. `qw.rsi` was a **function**. Same registry, same generator, no error, no warning — and the difference was pure luck.

The generated TA registry added in 0.7.0 (`5ipk.3`) derives native batch symbol names with `pascal_to_snake()` (`SuperTrend` → `super_trend`), but the `export_*!` macros emit `pub fn [<$name:lower>]` (`SuperTrend` → `supertrend`). Every multi-word name missed. The 44 single-word names (`rsi`, `sma`, `atr`) survived only because `pascal_to_snake("Rsi") == "rsi"`.

`_resolve_ta_binding` treated the miss as a fallback and returned `native_streaming` — a class with a completely different calling convention. **68 of 221 indicators** were affected. 0.6 had no registry layer and bound native symbols directly, which is why it was unaffected: this is a 0.7 regression.

## Why this matters beyond the bug

This is the `GMM::fit()` disease from `planning/BRUTAL_REVIEW_2026-07-07.md`: a public API reporting success while doing something other than what the caller asked. The cost here was not just wrong behavior — the silence **manufactured a false explanation**. An agent investigating `qw.supertrend` being a class concluded 0.7 had *intentionally* moved SuperTrend to the `.ta` expression namespace, and planned a downstream compiler refactor around a two-line codegen bug.

The test could not catch it by construction:

```python
assert (entry.get("native_batch") or entry.get("native_streaming")
        or entry.get("polars_method")), slug
```

It asserted a name was *present*, never that it *resolved*. `native_batch: "super_trend"` passed cleanly.

## Changes

- **`scripts/generate_api_stubs.py`** — derive batch names with `.lower()`, matching the macro. Repairs 61.
- **`scripts/api_slug_aliases.json`** — 4 stale snake_cased names (`fm_demodulator`, `fourier_series_model`, `my_rsi`, `precision_trend_analysis`); 3 aliases declaring batch exports that do not exist now fall through to their polars methods (`linreg`, `oc2`, `true_range`); `sr_monitor` dropped `SrInteractionMonitor`, a class that exists only as a string in `metadata_registry.rs` and was never exported to Python.
- **`quantwave-py/python/quantwave/__init__.py`** — `_resolve_ta_binding` raises `ImportError` when a declared `native_batch` symbol is absent from the build, instead of silently substituting the streaming class. A `native_batch` of `None` still falls through to streaming/polars unchanged (intentionally streaming-only indicators keep working).
- **`tests/python/test_api_surface.py`** — assert every declared native symbol resolves against the compiled module, plus a regression test that multi-word slugs bind as batch functions. This test found a 69th mismatch (`sr_monitor`) during development.
- **`_ta_registry_generated.py`** — regenerated: 68 insertions, 68 deletions, exactly the predicted blast radius.

## Compatibility

None required. `qw.supertrend(period=10, multiplier=3.0, high=..., low=..., close=...)` again returns `list[SuperTrendResult]` — the exact 0.6 calling convention.

## Verification

Run against a real 0.7.0 environment:

- 221 slugs · **0** declared-batch-bound-as-class · **0** registry names absent from build
- 127 bound as batch functions; 2 legitimately streaming-only
- `tests/python/`: **179 passed**. The 2 failures (`test_sma_parity`, `test_correctness_precheck_runs`) are **pre-existing** and reproduce on a clean tree via `git stash`.

## Follow-up (not in this PR)

`test_sma_parity` fails on `df.lazy().ta.sma(...)` with `'LazyFrame' object has no attribute 'ta'`. The `.ta` namespace is registered on `Expr`, not LazyFrame — the test encodes the same wrong mental model that misled the agent investigating this bug. Worth fixing separately.

Closes `quantwave-84cu`

🤖 Generated with [Claude Code](https://claude.com/claude-code)