### PR TITLE
fix(test): repair stale test_sma_parity to use the real .ta surface (qcsn)

### DIFF
--- a/tests/python/test_parity.py
+++ b/tests/python/test_parity.py
@@ -2,32 +2,33 @@ import polars as pl
 import quantwave as qw
 import pytest
 
+
 def test_sma_parity():
     # Test data
     data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
     df = pl.DataFrame({"close": data})
-    
-    # 1. Test Polars Namespace (.ta.sma)
     period = 3
-    # Use ta.sma since that's what we registered
-    result_df = df.lazy().ta.sma("close", period).collect()
-    
-    # Expected results (SMA period 3)
+
+    # Expected results (SMA period 3), partial averages during warmup:
     # 1.0 -> 1.0 / 1 = 1.0
     # 2.0 -> (1+2) / 2 = 1.5
     # 3.0 -> (1+2+3) / 3 = 2.0
     # 4.0 -> (2+3+4) / 3 = 3.0
     # ...
     expected_sma = [1.0, 1.5, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
-    
-    # The output column name in quantwave-polars is "sma" for the sma method
+
+    # 1. Polars expression namespace. `.ta` is registered on pl.Expr — not on
+    # DataFrame or LazyFrame — so it is reached through pl.col(...), which is
+    # then usable anywhere an expression is (select/with_columns, eager or lazy).
+    result_df = df.lazy().select(pl.col("close").ta.sma(period).alias("sma")).collect()
     actual_sma = result_df["sma"].to_list()
     assert actual_sma == pytest.approx(expected_sma)
-    
-    # 2. Test Streaming API (PySMA)
-    sma = qw.PySMA(period)
+
+    # 2. Streaming API — same Rust core, one value at a time.
+    sma = qw.streaming_class("sma")(period)
     streaming_results = [sma.next(v) for v in data]
     assert streaming_results == pytest.approx(expected_sma)
+
 
 if __name__ == "__main__":
     test_sma_parity()


### PR DESCRIPTION
## Summary

`tests/python/test_parity.py::test_sma_parity` has been failing on two stale API assumptions predating `5ipk.2` (which superseded it with gold-vector parity tests).

**The math was never wrong.** Expected `[1.0, 1.5, 2.0, 3.0, ...]` matches live 0.7 output on both paths exactly. This is an API repair, not a numerics change.

## The two stale calls

| Line | Was | Problem | Now |
|---|---|---|---|
| 13 | `df.lazy().ta.sma("close", period)` | `AttributeError: 'LazyFrame' object has no attribute 'ta'` — `.ta` is registered via `@pl.api.register_expr_namespace("ta")`, i.e. on `pl.Expr`, never on LazyFrame/DataFrame | `pl.col("close").ta.sma(period)`, kept lazy to preserve the original intent |
| 28 | `qw.PySMA(period)` | does not exist | `qw.streaming_class("sma")(period)` |

## Why repaired rather than deleted

`gold_parity` already covers SMA numerically, so deletion was on the table. Kept because the corrected test documents the exact surface the stale one misrepresented.

An in-repo test asserting `LazyFrame.ta` is an authoritative-looking source for a wrong mental model. During the `84cu` investigation (#14), an agent probing the 0.7 surface concluded `.ta` "isn't auto-registered" and folded that into a false narrative — that 0.7 had intentionally moved SuperTrend to the `.ta` expression namespace — which nearly triggered an unnecessary downstream compiler refactor. The library's silent fallback supplied the wrong answer; this test corroborated it. Two independent sources agreeing on a falsehood is how a reasonable investigation ends up planning work that was never needed.

The repaired version now demonstrates the correct surface: `.ta` binds to `Expr`, which is then usable anywhere an expression is — eager or lazy.

## Verification

- `tests/python/`: **180 passed** (was 179)
- The remaining failure, `test_correctness_precheck_runs`, is **unrelated and pre-existing**: `benchmarks/python_comparisons.py` needs `pandas`, absent from `.venv`. It should `pytest.importorskip("pandas")` rather than hard-fail — not filed yet.

Closes `quantwave-qcsn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)