### PR TITLE
fix(bench): treat pandas as optional in correctness_precheck

### DIFF
--- a/benchmarks/python_comparisons.py
+++ b/benchmarks/python_comparisons.py
@@ -33,8 +33,11 @@ def _library_versions() -> dict[str, str]:
     return versions
 
 
-def _tail_sma_pandas(close: np.ndarray, period: int) -> np.ndarray:
-    import pandas as pd
+def _tail_sma_pandas(close: np.ndarray, period: int) -> np.ndarray | None:
+    try:
+        import pandas as pd
+    except ImportError:
+        return None
 
     return pd.Series(close).rolling(period).mean().to_numpy()
 
@@ -80,12 +83,15 @@ def correctness_precheck(df: pl.DataFrame) -> dict[str, Any]:
 
     checks: dict[str, str] = {}
     pd_sma = _tail_sma_pandas(close, SMA_PERIOD)
-    mask = ~np.isnan(ref) & ~np.isnan(pd_sma)
-    if mask.any():
-        ok = np.allclose(ref[mask], pd_sma[mask], rtol=TOLERANCE, atol=TOLERANCE)
-        checks["pandas_rolling"] = "ok" if ok else "mismatch"
+    if pd_sma is not None:
+        mask = ~np.isnan(ref) & ~np.isnan(pd_sma)
+        if mask.any():
+            ok = np.allclose(ref[mask], pd_sma[mask], rtol=TOLERANCE, atol=TOLERANCE)
+            checks["pandas_rolling"] = "ok" if ok else "mismatch"
+        else:
+            checks["pandas_rolling"] = "insufficient_warmup"
     else:
-        checks["pandas_rolling"] = "insufficient_warmup"
+        checks["pandas_rolling"] = "not_installed"
 
     qw = _tail_sma_quantwave(small, SMA_PERIOD)
     if qw is not None:


### PR DESCRIPTION
## Summary

`test_correctness_precheck_runs` hard-failed with `ModuleNotFoundError: No module named 'pandas'`, taking the whole benchmark harness self-test down with it.

`benchmarks/python_comparisons.py` already treats every *other* comparison dependency as optional:

| helper | missing dep behaviour |
|---|---|
| `_tail_sma_talib` | returns `None` → `checks["talib"] = "not_installed"` |
| `_tail_sma_quantwave` | returns `None` → `checks["quantwave_ta"] = "skipped"` |
| `_collect_versions` | records `"not_installed"` for `talib` / `pandas_ta` |
| `_tail_sma_pandas` | **bare `import pandas as pd` → hard crash** |

Pandas was the sole mandatory dependency in a module built end-to-end to tolerate missing ones. `_tail_sma_pandas` now returns `None` on `ImportError`, and `correctness_precheck` records `"pandas_rolling": "not_installed"` — the same shape as the `talib` branch directly below it.

## Why not `pytest.importorskip("pandas")`

That was the obvious one-liner, and it's wrong. It skips the **entire** precheck, discarding the `quantwave_ta` correctness check — the one comparison that actually guards this library. A green-by-skipping test is exactly the kind of thing `planning/BRUTAL_REVIEW_2026-07-07.md` calls out.

Polars remains the reference (`_tail_sma_polars`), so a missing pandas costs one cross-check, not the precheck. Without pandas installed, the precheck now still runs and reports:

```
passed: True
  pandas_rolling   not_installed
  quantwave_ta     ok            <-- still guarding the library
  talib            not_installed
```

## Verification

- `tests/python/test_benchmark_harness.py`: **4 passed** (was 3 passed, 1 failed)
- `tests/python/`: 180 passed. The one remaining failure (`test_sma_parity`) is unrelated and fixed by #15; this branch is cut from main, so it still carries the stale version. With both merged: **181 passed, 0 failed**.

Relates to `quantwave-9gek.2` (benchmark harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)