### PR TITLE
feat(p2k0.6): ML feature namespace — extract + labels + leakage-safe CV splits

### DIFF
--- a/quantwave-py/python/quantwave/feature_extract.py
+++ b/quantwave-py/python/quantwave/feature_extract.py
@@ -1,0 +1,298 @@
+"""
+Unified ML feature extraction surface.
+
+Combines three existing, independently-tested extractors into one wide,
+leakage-safe feature matrix:
+
+- ``ta_core``: the classic/DSP batch indicator surface via ``df.ta.all()``
+  (:mod:`quantwave.bulk`).
+- ``ehlers``: Ehlers cycle/trend extractors (hurst, cyber_cycle,
+  griffiths_dominant_cycle, trendflex, instantaneous_trendline) via the
+  ``_apply_feature`` machinery in :mod:`quantwave.features`.
+- ``regimes``: the bull/bear HMM regime label, also via
+  :mod:`quantwave.features`.
+
+Plus a fourth, new set:
+
+- ``rolling_stats``: trailing-window mean/std/min/max of close and of
+  log-returns, and a rolling return z-score, as native Polars expressions.
+
+Every feature produced by every set is causal by construction: batch
+indicators only look backward over their configured window, the Ehlers/regime
+extractors are themselves streaming algorithms replayed in order, and
+``rolling_stats`` uses only ``rolling_*`` (trailing, ``center=False``)
+expressions and single-step ``shift(1)`` — never a forward fill or a
+centered window. Optional per-symbol grouping (``by=...``) processes each
+group as a fully independent sub-frame, so no feature for symbol A can ever
+be computed from symbol B's rows.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple
+
+from .features import FeatureSpec, _apply_feature
+
+if TYPE_CHECKING:
+    import polars as pl
+
+
+def _pl():
+    """Late-bind polars so ``import quantwave`` works without the optional extra."""
+    import polars as pl
+
+    return pl
+
+
+def _ensure_ta_all_registered() -> None:
+    """Import :mod:`quantwave.bulk` for its ``df.ta.all()`` registration side effect."""
+    from . import bulk  # noqa: F401
+
+
+# Ehlers cycle/trend extractors, mirroring quantwave.features.RECOMMENDED_PRESET
+# minus the regime label (split out below as its own feature set).
+_EHLERS_SPECS: List[FeatureSpec] = [
+    FeatureSpec("hurst", {"period": 100}),
+    FeatureSpec("cyber_cycle", {"length": 30}),
+    FeatureSpec("griffiths_dominant_cycle", {"lower": 6, "upper": 50, "length": 30}),
+    FeatureSpec("trendflex", {"length": 30}),
+    FeatureSpec("instantaneous_trendline", {}),
+]
+
+_REGIME_SPECS: List[FeatureSpec] = [
+    FeatureSpec("regime_hmm", {}),
+]
+
+_ROLLING_WINDOWS: Tuple[int, ...] = (5, 10, 20, 50)
+
+_KNOWN_FEATURE_SETS: Tuple[str, ...] = ("ta_core", "ehlers", "regimes", "rolling_stats")
+
+_DEFAULT_FEATURE_SETS: Tuple[str, ...] = _KNOWN_FEATURE_SETS
+
+
+def _leading_invalid_count(series: "pl.Series") -> int:
+    """Count leading null/NaN rows in ``series`` (warmup proxy for one column)."""
+    pl = _pl()
+    valid = series.is_not_null()
+    if series.dtype in (pl.Float32, pl.Float64):
+        valid = valid & series.is_not_nan()
+    true_idx = valid.arg_true()
+    return int(true_idx[0]) if len(true_idx) else series.len()
+
+
+def _check_no_collisions(existing_cols: Sequence[str], new_names: Sequence[str], feature_set: str) -> None:
+    collisions = sorted(set(existing_cols) & set(new_names))
+    if collisions:
+        raise ValueError(
+            f"feature set {feature_set!r} would overwrite existing column(s) {collisions}; "
+            "rename the input columns or drop the conflicting feature set"
+        )
+
+
+def _add_ta_core(sub: "pl.DataFrame") -> Tuple["pl.DataFrame", List[str], int]:
+    """Attach the classic/DSP batch indicator surface via ``df.ta.all()``."""
+    _ensure_ta_all_registered()
+    existing_cols = sub.columns
+    result, manifest = sub.ta.all()
+    cols = list(manifest["columns"])
+    _check_no_collisions(existing_cols, cols, "ta_core")
+    warmup = 0
+    for c in cols:
+        warmup = max(warmup, _leading_invalid_count(result[c]))
+    return result, cols, warmup
+
+
+def _add_spec_group(
+    sub: "pl.DataFrame", specs: Sequence[FeatureSpec], close_col: str, feature_set: str
+) -> Tuple["pl.DataFrame", List[str], int]:
+    """Attach columns from :mod:`quantwave.features`' ``_apply_feature`` machinery."""
+    pl = _pl()
+    closes = sub[close_col].cast(pl.Float64).to_list()
+    columns: Dict[str, List[float]] = {}
+    for spec in specs:
+        columns.update(_apply_feature(closes, spec))
+    names = list(columns.keys())
+    _check_no_collisions(sub.columns, names, feature_set)
+    if names:
+        sub = sub.with_columns([pl.Series(name, columns[name]) for name in names])
+    warmup = 0
+    for name in names:
+        warmup = max(warmup, _leading_invalid_count(sub[name]))
+    return sub, names, warmup
+
+
+def _add_rolling_stats(
+    sub: "pl.DataFrame", close_col: str, windows: Sequence[int] = _ROLLING_WINDOWS
+) -> Tuple["pl.DataFrame", List[str], int]:
+    """Trailing rolling stats of close and log-returns (leakage-safe: trailing only)."""
+    pl = _pl()
+    close = pl.col(close_col).cast(pl.Float64)
+    log_ret = (close / close.shift(1)).log()
+
+    exprs: List["pl.Expr"] = []
+    names: List[str] = []
+    for w in windows:
+        window_specs = [
+            (f"roll_mean_{w}", close.rolling_mean(w)),
+            (f"roll_std_{w}", close.rolling_std(w)),
+            (f"roll_min_{w}", close.rolling_min(w)),
+            (f"roll_max_{w}", close.rolling_max(w)),
+            (f"logret_mean_{w}", log_ret.rolling_mean(w)),
+            (f"logret_std_{w}", log_ret.rolling_std(w)),
+            (f"logret_zscore_{w}", (log_ret - log_ret.rolling_mean(w)) / log_ret.rolling_std(w)),
+        ]
+        for name, expr in window_specs:
+            exprs.append(expr.alias(name))
+            names.append(name)
+
+    _check_no_collisions(sub.columns, names, "rolling_stats")
+    sub = sub.with_columns(exprs)
+    warmup = 0
+    for name in names:
+        warmup = max(warmup, _leading_invalid_count(sub[name]))
+    return sub, names, warmup
+
+
+def _process_group(
+    sub: "pl.DataFrame", feature_sets: Sequence[str], close_col: str
+) -> Tuple["pl.DataFrame", Dict[str, List[str]], Dict[str, int]]:
+    """Apply every requested feature set to one fully independent sub-frame."""
+    names_by_set: Dict[str, List[str]] = {}
+    warmup_by_set: Dict[str, int] = {}
+
+    for fs in feature_sets:
+        if fs == "ta_core":
+            sub, names, warmup = _add_ta_core(sub)
+        elif fs == "ehlers":
+            sub, names, warmup = _add_spec_group(sub, _EHLERS_SPECS, close_col, fs)
+        elif fs == "regimes":
+            sub, names, warmup = _add_spec_group(sub, _REGIME_SPECS, close_col, fs)
+        elif fs == "rolling_stats":
+            sub, names, warmup = _add_rolling_stats(sub, close_col)
+        else:  # pragma: no cover - guarded earlier in extract()
+            raise ValueError(f"Unknown feature set: {fs!r}")
+        names_by_set[fs] = names
+        warmup_by_set[fs] = warmup
+
+    return sub, names_by_set, warmup_by_set
+
+
+def extract(
+    df: "pl.DataFrame",
+    feature_sets: Sequence[str] = _DEFAULT_FEATURE_SETS,
+    by: Optional[str] = None,
+    horizon: Optional[int] = None,
+    close_col: str = "close",
+) -> Tuple["pl.DataFrame", List[str], Dict[str, Any]]:
+    """Build a unified, leakage-safe ML feature matrix.
+
+    Every feature at row t is computed from rows <= t only:
+
+    - ``ta_core`` uses ``df.ta.all()``, the trailing-window classic/DSP
+      indicator surface.
+    - ``ehlers`` and ``regimes`` replay the streaming Ehlers cycle/trend and
+      HMM regime extractors bar-by-bar via
+      :mod:`quantwave.features`'s ``_apply_feature``.
+    - ``rolling_stats`` uses only trailing (``center=False``) rolling
+      expressions and single-step ``shift(1)`` — never a forward fill or a
+      centered window.
+
+    Args:
+        df: Input DataFrame or LazyFrame (collected internally) containing at
+            least ``close_col``, plus whatever OHLCV columns the requested
+            ``ta_core`` indicators need (columns they require but don't find
+            are skipped, not errored — see ``df.ta.all()``'s manifest).
+        feature_sets: Which feature groups to compute, in output order.
+            One or more of ``"ta_core"``, ``"ehlers"``, ``"regimes"``,
+            ``"rolling_stats"``.
+        by: Optional grouping column (e.g. ``"symbol"``). When given, every
+            feature set is computed independently per group value — no
+            feature for one group's rows is ever derived from another
+            group's rows. Row order in the returned frame matches the input
+            frame's order regardless of how groups are interleaved.
+        horizon: Optional forward-looking bar count reserved for the
+            caller's own label construction (e.g. "predict return over the
+            next `horizon` bars"). Not used to compute any feature here —
+            doing so would introduce lookahead — and is only echoed back in
+            ``metadata["horizon"]`` for the caller's convenience.
+        close_col: Name of the close-price column.
+
+    Returns:
+        A 3-tuple ``(features_df, feature_names, metadata)``:
+
+        - ``features_df``: the input columns plus every added feature
+          column.
+        - ``feature_names``: the list of added feature column names, in the
+          order the feature sets were requested (and, within a set, the
+          order that set's columns were produced).
+        - ``metadata``: ``{feature_set_name: {"feature_names": [...],
+          "warmup": int}, ...}`` for each requested feature set, plus
+          ``"warmup"`` (the max across sets), ``"by"``, ``"horizon"``, and
+          ``"n_rows"``. ``warmup`` is the number of leading rows (per set)
+          that contain a null/NaN in at least one of that set's columns —
+          i.e. the number of rows a caller should trim before training.
+
+    Example:
+        >>> import quantwave as qw
+        >>> from quantwave.feature_extract import extract
+        >>> features_df, feature_names, metadata = extract(
+        ...     ohlcv_df, feature_sets=("ta_core", "rolling_stats"), by="symbol"
+        ... )
+    """
+    pl = _pl()
+    if isinstance(df, pl.LazyFrame):
+        df = df.collect()
+    if close_col not in df.columns:
+        raise ValueError(f"close column {close_col!r} not in DataFrame")
+    if by is not None and by not in df.columns:
+        raise ValueError(f"group column {by!r} not in DataFrame")
+
+    requested = list(feature_sets)
+    if not requested:
+        raise ValueError("feature_sets must be non-empty")
+    unknown = sorted(set(requested) - set(_KNOWN_FEATURE_SETS))
+    if unknown:
+        raise ValueError(
+            f"Unknown feature set(s): {unknown}; known sets are {list(_KNOWN_FEATURE_SETS)}"
+        )
+
+    idx_col = "__qw_extract_row_idx__"
+    indexed = df.with_row_index(idx_col)
+
+    group_keys: List[Any]
+    if by is None:
+        group_keys = [None]
+    else:
+        group_keys = indexed[by].unique(maintain_order=True).to_list()
+
+    processed_frames: List["pl.DataFrame"] = []
+    names_by_set: Dict[str, List[str]] = {fs: [] for fs in requested}
+    warmup_by_set: Dict[str, int] = {fs: 0 for fs in requested}
+
+    for key in group_keys:
+        sub = indexed if key is None else indexed.filter(pl.col(by) == key)
+        sub_result, sub_names, sub_warmup = _process_group(sub, requested, close_col)
+        processed_frames.append(sub_result)
+        for fs in requested:
+            if not names_by_set[fs]:
+                names_by_set[fs] = sub_names[fs]
+            warmup_by_set[fs] = max(warmup_by_set[fs], sub_warmup[fs])
+
+    result = processed_frames[0] if len(processed_frames) == 1 else pl.concat(
+        processed_frames, how="vertical"
+    )
+    result = result.sort(idx_col).drop(idx_col)
+
+    feature_names: List[str] = []
+    for fs in requested:
+        feature_names.extend(names_by_set[fs])
+
+    metadata: Dict[str, Any] = {
+        fs: {"feature_names": names_by_set[fs], "warmup": warmup_by_set[fs]} for fs in requested
+    }
+    metadata["warmup"] = max(warmup_by_set.values()) if warmup_by_set else 0
+    metadata["by"] = by
+    metadata["horizon"] = horizon
+    metadata["n_rows"] = result.height
+
+    return result, feature_names, metadata

--- a/quantwave-py/python/quantwave/feature_labels.py
+++ b/quantwave-py/python/quantwave/feature_labels.py
@@ -1,0 +1,222 @@
+"""ML label helpers: forward returns and triple-barrier labeling.
+
+Both helpers produce *targets* (labels) built from future price data — using
+the future here is correct because these columns feed supervised-learning
+targets, not point-in-time features. Callers must still be careful never to
+join these columns back in as model *inputs* for the same timestamp.
+
+Triple-barrier definition (Lopez de Prado, kept intentionally simple):
+
+    From each bar ``t``, look forward over bars ``t+1 .. t+max_holding``
+    (a closed/inclusive window of up to ``max_holding`` bars).
+
+    ``upper = price[t] * (1 + pt)``
+    ``lower = price[t] * (1 - sl)``
+
+    The first bar in the window with ``price >= upper`` touches the profit
+    barrier -> ``label = +1``, ``touch_kind = "pt"``.
+    The first bar in the window with ``price <= lower`` touches the loss
+    barrier -> ``label = -1``, ``touch_kind = "sl"``.
+    First touch (by bar order) wins. If a single bar satisfies both
+    conditions simultaneously (only possible with degenerate/non-positive
+    ``pt``/``sl``), the profit barrier wins by convention.
+
+    If neither barrier is touched anywhere in the window, the vertical
+    (time) barrier applies -> ``label = 0``, ``touch_kind = "time"``,
+    ``touch_idx = t + max_holding``.
+
+    Tie policy: a touch landing exactly on bar ``t + max_holding`` still
+    counts as a profit/loss touch, not a time-out — the window is closed on
+    the right, so the last bar is eligible for both barrier and time checks,
+    and barrier touches take priority.
+
+    If fewer than ``max_holding`` future bars exist (end of the series or
+    end of the symbol's own data when ``by`` is set) and no barrier was
+    touched in the bars that *do* exist, the verdict is undetermined:
+    ``label``, ``touch_idx``, and ``touch_kind`` are all null. This mirrors
+    ``forward_returns``' convention of nulling rows with insufficient future
+    data rather than fabricating a verdict.
+
+    ``pt``/``sl`` are fractional thresholds (e.g. ``0.02`` == 2%) and may be
+    passed as a column name instead of a scalar, in which case each row uses
+    its own per-row threshold (e.g. an ATR-scaled column computed upstream).
+
+    ``touch_idx`` is the bar index within the symbol's own series: 0-based,
+    local to each group when ``by`` is supplied (not a global row offset).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List, Optional, Sequence, Union
+
+if TYPE_CHECKING:
+    import polars as pl
+
+
+def _pl():
+    """Late-bind polars so ``import quantwave`` works without the optional extra."""
+    import polars as pl
+
+    return pl
+
+
+def forward_returns(
+    df: "pl.DataFrame",
+    horizons: Sequence[int] = (1, 5, 10),
+    price: str = "close",
+    by: Optional[str] = None,
+) -> "pl.DataFrame":
+    """Add forward-return label columns ``fwd_ret_{h}`` for each horizon.
+
+    ``fwd_ret_{h}[t] = (price[t+h] - price[t]) / price[t]``.
+
+    The last ``h`` rows of each horizon (per symbol, when ``by`` is given)
+    are null since no future price exists to compute the return. When
+    ``by`` is set, horizons never look past the end of a symbol's own rows
+    into the next symbol's data.
+
+    Args:
+        df: Input DataFrame containing at least the ``price`` column (and
+            ``by`` column, if given).
+        horizons: Bar counts to look forward.
+        price: Column to compute returns from.
+        by: Optional symbol/group column; horizons are computed
+            independently within each group and never cross group
+            boundaries.
+
+    Returns:
+        ``df`` with one added column ``fwd_ret_{h}`` per horizon.
+    """
+    pl = _pl()
+    if by is None:
+        return _forward_returns_single(df, horizons, price)
+
+    parts = df.partition_by(by, maintain_order=True)
+    computed = [_forward_returns_single(part, horizons, price) for part in parts]
+    return pl.concat(computed)
+
+
+def _forward_returns_single(
+    df: "pl.DataFrame",
+    horizons: Sequence[int],
+    price: str,
+) -> "pl.DataFrame":
+    pl = _pl()
+    prices = df[price].cast(pl.Float64).to_list()
+    n = len(prices)
+
+    new_cols = {}
+    for h in horizons:
+        col: List[Optional[float]] = [None] * n
+        for t in range(n - h):
+            p0 = prices[t]
+            col[t] = (prices[t + h] - p0) / p0 if p0 else None
+        new_cols[f"fwd_ret_{h}"] = col
+
+    return df.with_columns(
+        [pl.Series(name, values, dtype=pl.Float64) for name, values in new_cols.items()]
+    )
+
+
+def triple_barrier(
+    df: "pl.DataFrame",
+    price: str = "close",
+    pt: Union[float, str] = 0.02,
+    sl: Union[float, str] = 0.02,
+    max_holding: int = 10,
+    by: Optional[str] = None,
+) -> "pl.DataFrame":
+    """Label each bar with the López de Prado triple-barrier method.
+
+    See the module docstring for the precise barrier math and tie policy.
+    Adds three columns: ``label`` (``-1``/``0``/``+1``), ``touch_idx`` (bar
+    index of the first touch, local to the symbol's own series), and
+    ``touch_kind`` (``"pt"``/``"sl"``/``"time"``).
+
+    Args:
+        df: Input DataFrame containing at least the ``price`` column (and
+            ``by``/``pt``/``sl`` columns, if given as column names).
+        price: Column to evaluate barriers against.
+        pt: Profit-taking threshold, fractional (e.g. ``0.02`` == 2% above
+            entry price), either a scalar applied to every row or the name
+            of a per-row threshold column.
+        sl: Stop-loss threshold, fractional, same scalar-or-column rules
+            as ``pt``.
+        max_holding: Maximum number of bars to hold before the vertical
+            (time) barrier applies.
+        by: Optional symbol/group column; barrier windows are computed
+            independently within each group and never look into the next
+            symbol's rows.
+
+    Returns:
+        ``df`` with added ``label``, ``touch_idx``, ``touch_kind`` columns.
+    """
+    pl = _pl()
+    if by is None:
+        return _triple_barrier_single(df, price, pt, sl, max_holding)
+
+    parts = df.partition_by(by, maintain_order=True)
+    computed = [_triple_barrier_single(part, price, pt, sl, max_holding) for part in parts]
+    return pl.concat(computed)
+
+
+def _triple_barrier_single(
+    df: "pl.DataFrame",
+    price: str,
+    pt: Union[float, str],
+    sl: Union[float, str],
+    max_holding: int,
+) -> "pl.DataFrame":
+    pl = _pl()
+    prices = df[price].cast(pl.Float64).to_list()
+    n = len(prices)
+
+    pt_vals = (
+        df[pt].cast(pl.Float64).to_list() if isinstance(pt, str) else [float(pt)] * n
+    )
+    sl_vals = (
+        df[sl].cast(pl.Float64).to_list() if isinstance(sl, str) else [float(sl)] * n
+    )
+
+    labels: List[Optional[int]] = [None] * n
+    touch_idx: List[Optional[int]] = [None] * n
+    touch_kind: List[Optional[str]] = [None] * n
+
+    for t in range(n):
+        p0 = prices[t]
+        upper = p0 * (1.0 + pt_vals[t])
+        lower = p0 * (1.0 - sl_vals[t])
+
+        window_end = min(t + max_holding, n - 1)
+        found = False
+        for k in range(t + 1, window_end + 1):
+            pk = prices[k]
+            hit_upper = pk >= upper
+            hit_lower = pk <= lower
+            if hit_upper:
+                labels[t] = 1
+                touch_idx[t] = k
+                touch_kind[t] = "pt"
+                found = True
+                break
+            if hit_lower:
+                labels[t] = -1
+                touch_idx[t] = k
+                touch_kind[t] = "sl"
+                found = True
+                break
+
+        if not found:
+            if t + max_holding <= n - 1:
+                labels[t] = 0
+                touch_idx[t] = t + max_holding
+                touch_kind[t] = "time"
+            # else: insufficient future bars to reach a verdict -> leave null
+
+    return df.with_columns(
+        [
+            pl.Series("label", labels, dtype=pl.Int64),
+            pl.Series("touch_idx", touch_idx, dtype=pl.Int64),
+            pl.Series("touch_kind", touch_kind, dtype=pl.Utf8),
+        ]
+    )

--- a/quantwave-py/python/quantwave/feature_splits.py
+++ b/quantwave-py/python/quantwave/feature_splits.py
@@ -1,0 +1,189 @@
+"""Leakage-safe cross-validation split helpers for time-ordered features.
+
+Implements the purged K-fold (with embargo) and walk-forward splitters
+described by Lopez de Prado (*Advances in Financial Machine Learning*).
+Both splitters are pure-index (numpy) based: they take a sample count and
+return ``(train_idx, test_idx)`` index arrays rather than touching any
+DataFrame directly, so callers can apply them to any array-like of the same
+length.
+
+The guarantee both splitters exist to provide: after purge + embargo (or,
+for walk-forward, after the embargo gap), no train index can leak
+information about a test index -- either because it shares a timestamp with
+the test fold, because its label window overlaps the test interval, or
+because it falls inside the embargo band immediately following the test
+fold.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+FoldList = List[Tuple[np.ndarray, np.ndarray]]
+
+
+def purged_kfold(
+    n_samples: int,
+    n_splits: int = 5,
+    t1: Optional[np.ndarray] = None,
+    embargo: float = 0.0,
+) -> FoldList:
+    """K-fold splits over time-ordered samples with purging and embargo.
+
+    Samples ``0..n_samples-1`` are assumed to be in time order. The
+    timeline is partitioned into ``n_splits`` contiguous, disjoint test
+    folds (a plain contiguous K-fold partition, before any purging). For
+    each test fold ``[test_lo, test_hi]``:
+
+    - **Purge**: a train candidate ``i`` is removed if its label span
+      ``[i, t1[i]]`` overlaps the test interval, i.e. ``i <= test_hi and
+      t1[i] >= test_lo``. If ``t1`` is ``None`` each sample is treated as a
+      point label (``t1[i] = i``), so purging only removes the
+      fold-adjacent boundary -- i.e. the test fold itself (already
+      excluded); no additional overlap is possible without label-horizon
+      information.
+    - **Embargo**: train candidates in ``(test_hi, test_hi + embargo_count]``
+      are removed, where ``embargo_count = int(embargo * n_samples)``. This
+      is independent of ``t1`` and only ever trims samples immediately
+      *after* the test fold.
+
+    Args:
+        n_samples: total number of time-ordered samples.
+        n_splits: number of contiguous test folds (>= 1).
+        t1: optional array of length ``n_samples`` mapping each sample
+            index to the index at which its label is realized (its label
+            horizon). ``t1[i] >= i`` is expected.
+        embargo: fraction of ``n_samples`` to embargo immediately after
+            each test fold (0.0 disables embargo).
+
+    Returns:
+        A list of ``(train_idx, test_idx)`` numpy index array pairs, one
+        per non-empty test fold.
+    """
+    if n_samples <= 0:
+        raise ValueError("n_samples must be positive")
+    if n_splits < 1:
+        raise ValueError("n_splits must be >= 1")
+    if embargo < 0:
+        raise ValueError("embargo must be non-negative")
+
+    indices = np.arange(n_samples)
+
+    if t1 is None:
+        span_end = indices.copy()
+    else:
+        span_end = np.asarray(t1)
+        if span_end.shape[0] != n_samples:
+            raise ValueError("t1 must have length n_samples")
+
+    embargo_count = int(embargo * n_samples)
+    fold_bounds = np.array_split(indices, n_splits)
+
+    folds: FoldList = []
+    for test_idx in fold_bounds:
+        if len(test_idx) == 0:
+            continue
+        test_lo = int(test_idx[0])
+        test_hi = int(test_idx[-1])
+
+        keep_mask = np.ones(n_samples, dtype=bool)
+        keep_mask[test_idx] = False  # exclude the test fold itself
+
+        candidates = indices[keep_mask]
+        candidate_span_end = span_end[candidates]
+
+        # Purge: label span [i, t1[i]] overlaps [test_lo, test_hi].
+        purge_mask = (candidates <= test_hi) & (candidate_span_end >= test_lo)
+
+        # Embargo: fixed band strictly after the test fold.
+        embargo_mask = (candidates > test_hi) & (
+            candidates <= test_hi + embargo_count
+        )
+
+        train = candidates[~(purge_mask | embargo_mask)]
+        folds.append((train, test_idx))
+
+    return folds
+
+
+def walk_forward(
+    n_samples: int,
+    n_splits: int,
+    expanding: bool = True,
+    min_train: Optional[int] = None,
+    embargo: float = 0.0,
+) -> FoldList:
+    """Time-ordered forward-chaining splits with an embargo gap.
+
+    The timeline is split so that an initial training block of at least
+    ``min_train`` samples is followed by ``n_splits`` contiguous test
+    folds carved out of the remaining samples. For fold ``k`` the test
+    fold always starts strictly after the corresponding train fold ends,
+    separated by an embargo gap of ``embargo_count = int(embargo *
+    n_samples)`` samples:
+
+    - ``expanding=True``: train is every sample from ``0`` up to
+      ``test_start - embargo_count`` (train grows each fold).
+    - ``expanding=False``: train is a rolling window of (up to) the
+      initial train size immediately preceding the embargo gap (train
+      size is capped, not grown).
+
+    Args:
+        n_samples: total number of time-ordered samples.
+        n_splits: number of forward test folds (>= 1).
+        expanding: expanding-window train (default) vs. rolling-window
+            train.
+        min_train: minimum number of samples in the initial training
+            block. Defaults to ``n_samples // (n_splits + 1)`` (at least
+            1).
+        embargo: fraction of ``n_samples`` to leave as a gap between the
+            end of train and the start of test.
+
+    Returns:
+        A list of ``(train_idx, test_idx)`` numpy index array pairs.
+        Folds where the embargo gap would consume the entire train
+        window are skipped (empty-train folds are not returned).
+    """
+    if n_samples <= 0:
+        raise ValueError("n_samples must be positive")
+    if n_splits < 1:
+        raise ValueError("n_splits must be >= 1")
+    if embargo < 0:
+        raise ValueError("embargo must be non-negative")
+
+    if min_train is None:
+        min_train = max(1, n_samples // (n_splits + 1))
+    if min_train >= n_samples:
+        raise ValueError("min_train must be smaller than n_samples")
+
+    embargo_count = int(embargo * n_samples)
+    remaining = np.arange(min_train, n_samples)
+    if len(remaining) == 0:
+        raise ValueError("no samples remain for test folds after min_train")
+
+    test_fold_bounds = np.array_split(remaining, n_splits)
+    window_size = min_train
+
+    folds: FoldList = []
+    for test_idx in test_fold_bounds:
+        if len(test_idx) == 0:
+            continue
+        test_start = int(test_idx[0])
+        train_end = test_start - embargo_count
+        if train_end <= 0:
+            continue
+
+        if expanding:
+            train = np.arange(0, train_end)
+        else:
+            train_start = max(0, train_end - window_size)
+            train = np.arange(train_start, train_end)
+
+        if len(train) == 0:
+            continue
+
+        folds.append((train, test_idx))
+
+    return folds

--- a/quantwave-py/python/quantwave/features.py
+++ b/quantwave-py/python/quantwave/features.py
@@ -219,3 +219,18 @@ def feature_column_names(
     for spec in specs:
         names.extend(_apply_feature([100.0] * 3, spec).keys())
     return names
+
+
+# ML pipeline surface: bulk feature extraction, labels, and leakage-safe CV
+# splits. Imported at the end so FeatureSpec/_apply_feature (above) are already
+# defined when feature_extract imports them back — avoids a circular import.
+# Guarded because these need numpy/polars (optional extras) — feature_splits
+# imports numpy at module load — while the core install ships neither; they are
+# unusable without those deps anyway, so skipping them keeps `import quantwave`
+# working on a bare core install.
+try:
+    from .feature_extract import extract  # noqa: E402,F401
+    from .feature_labels import forward_returns, triple_barrier  # noqa: E402,F401
+    from .feature_splits import purged_kfold, walk_forward  # noqa: E402,F401
+except ImportError:  # pragma: no cover - core install without numpy/polars
+    pass

--- a/tests/python/test_feature_extract.py
+++ b/tests/python/test_feature_extract.py
@@ -1,0 +1,216 @@
+"""TDD tests for the unified ML feature extraction surface (``feature_extract.extract``).
+
+Leakage safety is the primary guarantee under test: every feature at row t must be a
+function of information at rows <= t only. The leakage-property test (below) mutates
+all rows strictly after some index t with extreme values and asserts the recomputed
+feature rows at indices <= t are bit-identical — a feature that changes proves
+lookahead into the mutated future.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+pl = pytest.importorskip("polars")
+
+from quantwave import datasets
+from quantwave.feature_extract import extract
+
+FEATURE_SETS = ("ta_core", "ehlers", "regimes", "rolling_stats")
+
+
+def _base_df(rows: int = 260, seed: int = 7):
+    return datasets.synthetic(seed=seed, rows=rows)
+
+
+def _mutate_after(df: "pl.DataFrame", t: int, cols=("open", "high", "low", "close", "volume")):
+    """Return a copy of ``df`` with all rows at index > t set to extreme values."""
+    idx_col = "__test_idx__"
+    tagged = df.with_row_index(idx_col)
+    exprs = [
+        pl.when(pl.col(idx_col) > t)
+        .then(pl.lit(1.0e9))
+        .otherwise(pl.col(c))
+        .alias(c)
+        for c in cols
+        if c in df.columns
+    ]
+    return tagged.with_columns(exprs).drop(idx_col)
+
+
+def _values_equal(va, vb) -> bool:
+    """NaN-aware, struct-aware equality (equal_nan semantics for nested dicts too)."""
+    if va is None and vb is None:
+        return True
+    if isinstance(va, float) and isinstance(vb, float):
+        if math.isnan(va) and math.isnan(vb):
+            return True
+        return va == vb
+    if isinstance(va, dict) and isinstance(vb, dict):
+        if va.keys() != vb.keys():
+            return False
+        return all(_values_equal(va[k], vb[k]) for k in va)
+    return va == vb
+
+
+def _assert_prefix_identical(a: "pl.DataFrame", b: "pl.DataFrame", names, upto: int, label: str):
+    for name in names:
+        va_list = a[name][: upto + 1].to_list()
+        vb_list = b[name][: upto + 1].to_list()
+        assert len(va_list) == len(vb_list)
+        for i, (va, vb) in enumerate(zip(va_list, vb_list)):
+            assert _values_equal(va, vb), (
+                f"{label}/{name} leaked future information: row {i} (<= t={upto}) "
+                f"changed from {va!r} to {vb!r} after mutating rows > t"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 1. Leakage property — the core guarantee, run over every feature set.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("feature_set", FEATURE_SETS)
+def test_leakage_property_single_feature_set(feature_set):
+    df = _base_df()
+    t = 150
+
+    features_a, names_a, _ = extract(df, feature_sets=(feature_set,))
+    mutated = _mutate_after(df, t)
+    features_b, names_b, _ = extract(mutated, feature_sets=(feature_set,))
+
+    assert names_a == names_b
+    assert names_a, f"{feature_set} produced no feature columns to check"
+    _assert_prefix_identical(features_a, features_b, names_a, t, feature_set)
+
+
+def test_leakage_property_all_feature_sets_combined():
+    df = _base_df()
+    t = 150
+
+    features_a, names_a, _ = extract(df, feature_sets=FEATURE_SETS)
+    mutated = _mutate_after(df, t)
+    features_b, names_b, _ = extract(mutated, feature_sets=FEATURE_SETS)
+
+    assert names_a == names_b
+    _assert_prefix_identical(features_a, features_b, names_a, t, "combined")
+
+
+def test_leakage_property_with_grouping():
+    df = datasets.synthetic(seed=13, rows=180, symbols=["AAA", "BBB"])
+    t = 90
+
+    features_a, names_a, _ = extract(df, feature_sets=FEATURE_SETS, by="symbol")
+    mutated = _mutate_after(df, t)
+    features_b, names_b, _ = extract(mutated, feature_sets=FEATURE_SETS, by="symbol")
+
+    assert names_a == names_b
+    _assert_prefix_identical(features_a, features_b, names_a, t, "grouped")
+
+
+# ---------------------------------------------------------------------------
+# 2. feature_names contract.
+# ---------------------------------------------------------------------------
+
+
+def test_feature_names_exactly_equals_added_columns():
+    df = _base_df()
+    before_cols = set(df.columns)
+
+    features_df, feature_names, _ = extract(df, feature_sets=FEATURE_SETS)
+
+    added_cols = set(features_df.columns) - before_cols
+    assert set(feature_names) == added_cols
+    assert len(feature_names) == len(set(feature_names)), "duplicate feature names"
+
+
+# ---------------------------------------------------------------------------
+# 3. Multi-symbol isolation.
+# ---------------------------------------------------------------------------
+
+
+def test_multi_symbol_isolation():
+    rows = 220
+    df_multi = datasets.synthetic(seed=11, rows=rows, symbols=["AAA", "BBB"])
+
+    features_multi, names_multi, _ = extract(df_multi, feature_sets=FEATURE_SETS, by="symbol")
+
+    for sym in ("AAA", "BBB"):
+        df_single = df_multi.filter(pl.col("symbol") == sym).drop("symbol")
+        features_single, names_single, _ = extract(df_single, feature_sets=FEATURE_SETS)
+
+        assert names_single == names_multi
+
+        sub_multi = features_multi.filter(pl.col("symbol") == sym)
+        assert sub_multi.height == features_single.height
+
+        for name in names_single:
+            a_list = sub_multi[name].to_list()
+            b_list = features_single[name].to_list()
+            for i, (va, vb) in enumerate(zip(a_list, b_list)):
+                assert _values_equal(va, vb), (
+                    f"symbol {sym!r} feature {name!r} row {i} reflects cross-symbol "
+                    f"data: grouped={va!r} isolated={vb!r}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# 4. metadata contract.
+# ---------------------------------------------------------------------------
+
+
+def test_metadata_contract():
+    df = _base_df()
+    features_df, feature_names, metadata = extract(df, feature_sets=FEATURE_SETS)
+
+    union_names = []
+    for fs in FEATURE_SETS:
+        assert fs in metadata
+        info = metadata[fs]
+        assert "feature_names" in info
+        assert "warmup" in info
+        assert info["feature_names"], f"{fs} has empty feature_names"
+        union_names.extend(info["feature_names"])
+
+    # ta_core, ehlers, and rolling_stats are windowed -> nonzero warmup required.
+    for fs in ("ta_core", "ehlers", "rolling_stats"):
+        assert metadata[fs]["warmup"] > 0, f"{fs} warmup should be > 0"
+
+    assert set(union_names) == set(feature_names)
+
+
+def test_metadata_requested_subset_only():
+    df = _base_df()
+    _, feature_names, metadata = extract(df, feature_sets=("rolling_stats",))
+
+    assert set(metadata.keys()) >= {"rolling_stats"}
+    for fs in ("ta_core", "ehlers", "regimes"):
+        assert fs not in metadata
+    assert set(metadata["rolling_stats"]["feature_names"]) == set(feature_names)
+
+
+# ---------------------------------------------------------------------------
+# 5. Integration smoke — sklearn optional, must skip cleanly if absent.
+# ---------------------------------------------------------------------------
+
+
+def test_integration_smoke_sklearn_fit():
+    sklearn = pytest.importorskip("sklearn")
+    from sklearn.linear_model import LinearRegression
+
+    df = _base_df(rows=400)
+    features_df, feature_names, metadata = extract(df, feature_sets=FEATURE_SETS)
+
+    warmup = max(info["warmup"] for info in metadata.values() if isinstance(info, dict) and "warmup" in info)
+    trimmed = features_df.slice(warmup, features_df.height - warmup)
+
+    x = trimmed.select(feature_names).to_numpy()
+    y = trimmed["close"].to_numpy()
+
+    assert not bool((x != x).any()), "NaNs remain in feature matrix after warmup trim"
+
+    model = LinearRegression()
+    model.fit(x, y)
+    assert model.coef_.shape[0] == len(feature_names)

--- a/tests/python/test_feature_labels.py
+++ b/tests/python/test_feature_labels.py
@@ -1,0 +1,223 @@
+"""Tests for ML label helpers: forward returns and triple-barrier labeling."""
+
+from __future__ import annotations
+
+import pytest
+
+polars = pytest.importorskip("polars")
+pl = polars
+
+from quantwave.feature_labels import forward_returns, triple_barrier
+
+
+# ---------------------------------------------------------------------------
+# Triple-barrier gold fixtures
+# ---------------------------------------------------------------------------
+# Definition under test (see feature_labels.py docstring for the full spec):
+#   From bar t, look forward over bars t+1 .. t+max_holding (inclusive window).
+#   upper = price[t] * (1 + pt); lower = price[t] * (1 - sl).
+#   First bar in the window where price >= upper -> label +1, touch_kind "pt".
+#   First bar in the window where price <= lower -> label -1, touch_kind "sl".
+#   If a single bar satisfies both (degenerate), pt wins (upper barrier priority).
+#   If neither barrier is touched anywhere in the window -> label 0, touch_kind
+#   "time", touch_idx == t + max_holding (the vertical/time barrier).
+#   A touch landing exactly on bar t + max_holding still counts as a pt/sl touch,
+#   not a time-out (tie policy: the window is closed/inclusive on the right).
+#   touch_idx is the bar index *within the symbol's own series* (0-based, local
+#   to the group when `by` is used).
+
+
+def test_triple_barrier_pt_touched_first():
+    # Rises past +pt (upper=105) at k=3 before ever reaching -sl (lower=95, seen
+    # at k=4, which is later) -> label +1, touch_kind "pt", touch_idx 3.
+    prices = [100.0, 101.0, 102.0, 108.0, 90.0, 95.0]
+    df = pl.DataFrame({"close": prices})
+    out = triple_barrier(df, price="close", pt=0.05, sl=0.05, max_holding=4)
+
+    assert out["label"][0] == 1
+    assert out["touch_idx"][0] == 3
+    assert out["touch_kind"][0] == "pt"
+
+
+def test_triple_barrier_sl_touched_first():
+    # Falls to -sl (lower=95) at k=3 before ever reaching +pt (upper=105, only
+    # reached at k=4) -> label -1, touch_kind "sl", touch_idx 3.
+    prices = [100.0, 99.0, 97.0, 93.0, 110.0]
+    df = pl.DataFrame({"close": prices})
+    out = triple_barrier(df, price="close", pt=0.05, sl=0.05, max_holding=4)
+
+    assert out["label"][0] == -1
+    assert out["touch_idx"][0] == 3
+    assert out["touch_kind"][0] == "sl"
+
+
+def test_triple_barrier_time_barrier_when_neither_touched():
+    # Neither +/-10% barrier is touched within max_holding=4 bars -> label 0,
+    # touch_kind "time", touch_idx == t + max_holding == 4.
+    prices = [100.0, 101.0, 102.0, 103.0, 104.0]
+    df = pl.DataFrame({"close": prices})
+    out = triple_barrier(df, price="close", pt=0.10, sl=0.10, max_holding=4)
+
+    assert out["label"][0] == 0
+    assert out["touch_idx"][0] == 4
+    assert out["touch_kind"][0] == "time"
+
+
+def test_triple_barrier_tie_at_max_holding_counts_as_touch():
+    # Flat until the very last bar of the window, which lands exactly on
+    # t + max_holding and clears the pt barrier. Documented tie policy: this
+    # counts as a pt touch, NOT a time-out, because the window is inclusive.
+    prices = [100.0, 100.0, 100.0, 100.0, 106.0]
+    df = pl.DataFrame({"close": prices})
+    out = triple_barrier(df, price="close", pt=0.05, sl=0.05, max_holding=4)
+
+    assert out["label"][0] == 1
+    assert out["touch_idx"][0] == 4
+    assert out["touch_kind"][0] == "pt"
+
+
+def test_triple_barrier_incomplete_window_is_null():
+    # The last bar has no future bars at all, so no verdict can be reached
+    # (not even a time-barrier verdict, since we can't confirm max_holding
+    # bars elapsed without a touch). Labeled null, matching forward_returns'
+    # "insufficient future data -> null" convention.
+    prices = [100.0, 101.0, 102.0]
+    df = pl.DataFrame({"close": prices})
+    out = triple_barrier(df, price="close", pt=0.10, sl=0.10, max_holding=4)
+
+    assert out["label"][2] is None
+    assert out["touch_idx"][2] is None
+    assert out["touch_kind"][2] is None
+
+
+def test_triple_barrier_scalar_over_full_series():
+    # Sanity: every row gets a verdict of the expected shape/type for a longer
+    # series with mixed outcomes.
+    prices = [100.0, 100.0, 106.0, 106.0, 94.0, 94.0, 94.0, 94.0]
+    df = pl.DataFrame({"close": prices})
+    out = triple_barrier(df, price="close", pt=0.05, sl=0.05, max_holding=3)
+
+    assert out.height == len(prices)
+    assert set(out.columns) >= {"label", "touch_idx", "touch_kind"}
+    # t=0: window k=1..3 -> prices[2]=106 hits pt first (k=2)
+    assert out["label"][0] == 1
+    assert out["touch_kind"][0] == "pt"
+    assert out["touch_idx"][0] == 2
+
+
+# ---------------------------------------------------------------------------
+# forward_returns correctness
+# ---------------------------------------------------------------------------
+
+
+def test_forward_returns_values_match_hand_computation():
+    prices = [100.0, 102.0, 101.0, 105.0, 110.0, 108.0]
+    df = pl.DataFrame({"close": prices})
+    out = forward_returns(df, horizons=(1, 3), price="close")
+
+    n = len(prices)
+    for h in (1, 3):
+        col = out[f"fwd_ret_{h}"].to_list()
+        for t in range(n):
+            if t + h < n:
+                expected = (prices[t + h] - prices[t]) / prices[t]
+                assert col[t] == pytest.approx(expected)
+            else:
+                assert col[t] is None
+
+
+def test_forward_returns_last_h_rows_null():
+    prices = [1.0, 2.0, 3.0, 4.0, 5.0]
+    df = pl.DataFrame({"close": prices})
+    out = forward_returns(df, horizons=(1, 2, 4), price="close")
+
+    assert out["fwd_ret_1"][-1] is None
+    assert out["fwd_ret_2"][-1] is None
+    assert out["fwd_ret_2"][-2] is None
+    assert out["fwd_ret_4"][0] == pytest.approx((5.0 - 1.0) / 1.0)
+    assert out["fwd_ret_4"][1:].null_count() == len(prices) - 1
+
+
+# ---------------------------------------------------------------------------
+# Multi-symbol (`by`) boundary correctness — no cross-symbol leakage
+# ---------------------------------------------------------------------------
+
+
+def _two_symbol_df():
+    # Symbol A: gentle ramp ending at 104 (5 bars).
+    # Symbol B: starts at a wildly different level (1000) so any leakage
+    # across the boundary is numerically obvious.
+    a_prices = [100.0, 101.0, 102.0, 103.0, 104.0]
+    b_prices = [1000.0, 950.0, 1100.0, 900.0, 980.0]
+    return pl.DataFrame(
+        {
+            "symbol": ["A"] * len(a_prices) + ["B"] * len(b_prices),
+            "close": a_prices + b_prices,
+        }
+    )
+
+
+def test_forward_returns_no_cross_symbol_leakage():
+    df = _two_symbol_df()
+    out = forward_returns(df, horizons=(1, 2), price="close", by="symbol")
+
+    a_rows = out.filter(pl.col("symbol") == "A")
+    b_rows = out.filter(pl.col("symbol") == "B")
+
+    # Last row(s) of A must be null for both horizons, not filled from B.
+    assert a_rows["fwd_ret_1"][-1] is None
+    assert a_rows["fwd_ret_2"][-1] is None
+    assert a_rows["fwd_ret_2"][-2] is None
+
+    # First row of B computed purely from B's own prices.
+    expected = (1100.0 - 1000.0) / 1000.0
+    assert b_rows["fwd_ret_2"][0] == pytest.approx(expected)
+
+    # Last row of B is null (no future data at all, regardless of symbol).
+    assert b_rows["fwd_ret_1"][-1] is None
+
+
+def test_triple_barrier_no_cross_symbol_leakage():
+    df = _two_symbol_df()
+    # pt/sl huge enough that A's own prices never trigger a touch, so if the
+    # implementation leaked into B's 1000-level prices it would trigger
+    # spuriously (or produce a wildly different index).
+    out = triple_barrier(df, price="close", pt=5.0, sl=5.0, max_holding=3, by="symbol")
+
+    a_rows = out.filter(pl.col("symbol") == "A")
+    b_rows = out.filter(pl.col("symbol") == "B")
+
+    # A's rows never touch a 500%-away barrier within its own series ->
+    # every row is either "time" (label 0) or null (incomplete window), and
+    # touch_idx must stay within A's own local index range [0, 4].
+    for i in range(len(a_rows)):
+        kind = a_rows["touch_kind"][i]
+        assert kind in ("time", None)
+        idx = a_rows["touch_idx"][i]
+        if idx is not None:
+            assert idx <= 4
+
+    # B's first row touch_idx must be a local (small) index, not offset by
+    # A's length (which would indicate leakage/global indexing).
+    b_touch_idx = b_rows["touch_idx"][0]
+    if b_touch_idx is not None:
+        assert b_touch_idx <= 4
+
+
+# ---------------------------------------------------------------------------
+# Determinism
+# ---------------------------------------------------------------------------
+
+
+def test_forward_returns_deterministic():
+    df = _two_symbol_df()
+    out1 = forward_returns(df, horizons=(1, 2), price="close", by="symbol")
+    out2 = forward_returns(df, horizons=(1, 2), price="close", by="symbol")
+    assert out1.equals(out2)
+
+
+def test_triple_barrier_deterministic():
+    df = _two_symbol_df()
+    out1 = triple_barrier(df, price="close", pt=0.05, sl=0.05, max_holding=3, by="symbol")
+    out2 = triple_barrier(df, price="close", pt=0.05, sl=0.05, max_holding=3, by="symbol")
+    assert out1.equals(out2)

--- a/tests/python/test_feature_splits.py
+++ b/tests/python/test_feature_splits.py
@@ -1,0 +1,221 @@
+"""Tests for leakage-safe cross-validation split helpers.
+
+The single non-negotiable guarantee under test: after purge + embargo,
+there is zero overlap between any train fold and its corresponding test
+fold, and no train sample's label span (or the embargo band) touches the
+test interval.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from quantwave.feature_splits import purged_kfold, walk_forward
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _random_t1(rng: np.random.Generator, n_samples: int, max_horizon: int) -> np.ndarray:
+    """Random non-decreasing label horizons: t1[i] in [i, min(n_samples-1, i+H)]."""
+    horizons = rng.integers(0, max_horizon + 1, size=n_samples)
+    t1 = np.minimum(np.arange(n_samples) + horizons, n_samples - 1)
+    return t1
+
+
+# ---------------------------------------------------------------------------
+# 1. ZERO-OVERLAP PROPERTY (the core guarantee) -- write first.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("seed", range(20))
+def test_purged_kfold_zero_overlap_randomized(seed: int) -> None:
+    rng = np.random.default_rng(seed)
+    n_samples = int(rng.integers(20, 300))
+    n_splits = int(rng.integers(2, 8))
+    embargo = float(rng.choice([0.0, 0.01, 0.02, 0.05, 0.1]))
+    use_t1 = bool(rng.integers(0, 2))
+    t1 = None
+    if use_t1:
+        max_horizon = int(rng.integers(0, n_samples // 2 + 1))
+        t1 = _random_t1(rng, n_samples, max_horizon)
+
+    folds = purged_kfold(n_samples, n_splits=n_splits, t1=t1, embargo=embargo)
+    embargo_count = int(embargo * n_samples)
+
+    for train, test in folds:
+        train_set = set(train.tolist())
+        test_set = set(test.tolist())
+
+        # No index shared between train and test.
+        assert train_set & test_set == set()
+
+        if len(test) == 0:
+            continue
+        test_lo, test_hi = int(test[0]), int(test[-1])
+
+        span = t1 if t1 is not None else np.arange(n_samples)
+
+        for i in train:
+            i = int(i)
+            # Purge: train sample's label span must not overlap test interval.
+            lo, hi = i, int(span[i])
+            overlaps = (i <= test_hi) and (hi >= test_lo)
+            assert not overlaps, (
+                f"train idx {i} label span [{lo},{hi}] overlaps test "
+                f"interval [{test_lo},{test_hi}]"
+            )
+            # Embargo: no train sample immediately after the test fold
+            # within the embargo band.
+            in_embargo_band = test_hi < i <= test_hi + embargo_count
+            assert not in_embargo_band, (
+                f"train idx {i} falls inside embargo band after test "
+                f"fold ending at {test_hi} (embargo_count={embargo_count})"
+            )
+
+
+@pytest.mark.parametrize("seed", range(10))
+def test_walk_forward_zero_overlap_randomized(seed: int) -> None:
+    rng = np.random.default_rng(seed)
+    n_samples = int(rng.integers(20, 300))
+    n_splits = int(rng.integers(1, 6))
+    embargo = float(rng.choice([0.0, 0.01, 0.02, 0.05]))
+    expanding = bool(rng.integers(0, 2))
+
+    folds = walk_forward(
+        n_samples, n_splits=n_splits, expanding=expanding, embargo=embargo
+    )
+
+    for train, test in folds:
+        train_set = set(train.tolist())
+        test_set = set(test.tolist())
+        assert train_set & test_set == set()
+        if len(train) == 0 or len(test) == 0:
+            continue
+        assert int(train.max()) < int(test.min())
+
+
+# ---------------------------------------------------------------------------
+# 2. walk_forward strict time ordering.
+# ---------------------------------------------------------------------------
+
+
+def test_walk_forward_train_strictly_before_test() -> None:
+    folds = walk_forward(200, n_splits=5, expanding=True, embargo=0.0)
+    assert len(folds) > 0
+    for train, test in folds:
+        assert len(train) > 0 and len(test) > 0
+        assert int(train.max()) < int(test.min())
+
+
+def test_walk_forward_expanding_non_decreasing_train_size() -> None:
+    folds = walk_forward(300, n_splits=6, expanding=True, embargo=0.0)
+    sizes = [len(train) for train, _ in folds]
+    assert all(a <= b for a, b in zip(sizes, sizes[1:]))
+
+
+def test_walk_forward_embargo_gap_respected() -> None:
+    n_samples = 300
+    embargo = 0.02
+    embargo_count = int(embargo * n_samples)
+    folds = walk_forward(n_samples, n_splits=5, expanding=True, embargo=embargo)
+    for train, test in folds:
+        if len(train) == 0 or len(test) == 0:
+            continue
+        gap = int(test.min()) - int(train.max()) - 1
+        assert gap == embargo_count
+
+
+def test_walk_forward_rolling_window_train_size_bounded() -> None:
+    folds = walk_forward(300, n_splits=6, expanding=False, embargo=0.0)
+    sizes = [len(train) for train, _ in folds if len(train) > 0]
+    # Rolling window should never exceed the initial (max) train size.
+    assert max(sizes) == sizes[0] or all(s <= sizes[0] for s in sizes)
+
+
+# ---------------------------------------------------------------------------
+# 3. Coverage / partition sanity for purged_kfold test folds.
+# ---------------------------------------------------------------------------
+
+
+def test_purged_kfold_test_folds_partition_timeline() -> None:
+    n_samples = 137
+    n_splits = 5
+    folds = purged_kfold(n_samples, n_splits=n_splits, t1=None, embargo=0.0)
+
+    test_indices_concat: list[int] = []
+    for _, test in folds:
+        test_indices_concat.extend(test.tolist())
+
+    # Disjoint.
+    assert len(test_indices_concat) == len(set(test_indices_concat))
+    # Union covers all samples.
+    assert set(test_indices_concat) == set(range(n_samples))
+
+
+# ---------------------------------------------------------------------------
+# 4. Determinism + edge cases.
+# ---------------------------------------------------------------------------
+
+
+def test_purged_kfold_deterministic() -> None:
+    folds_a = purged_kfold(100, n_splits=4, t1=None, embargo=0.03)
+    folds_b = purged_kfold(100, n_splits=4, t1=None, embargo=0.03)
+    assert len(folds_a) == len(folds_b)
+    for (train_a, test_a), (train_b, test_b) in zip(folds_a, folds_b):
+        assert np.array_equal(train_a, train_b)
+        assert np.array_equal(test_a, test_b)
+
+
+def test_purged_kfold_embargo_zero_matches_plain_purged(monkeypatch=None) -> None:
+    n_samples = 60
+    t1 = np.arange(n_samples)  # trivial point labels
+    folds_embargo0 = purged_kfold(n_samples, n_splits=5, t1=t1, embargo=0.0)
+    folds_no_embargo_arg = purged_kfold(n_samples, n_splits=5, t1=t1)
+    assert len(folds_embargo0) == len(folds_no_embargo_arg)
+    for (tr0, te0), (tr1, te1) in zip(folds_embargo0, folds_no_embargo_arg):
+        assert np.array_equal(tr0, tr1)
+        assert np.array_equal(te0, te1)
+
+
+def test_purged_kfold_tiny_n_samples() -> None:
+    folds = purged_kfold(5, n_splits=2, t1=None, embargo=0.0)
+    assert len(folds) == 2
+    all_test = sorted(idx for _, test in folds for idx in test.tolist())
+    assert all_test == list(range(5))
+
+
+def test_purged_kfold_n_splits_one() -> None:
+    folds = purged_kfold(20, n_splits=1, t1=None, embargo=0.0)
+    assert len(folds) == 1
+    train, test = folds[0]
+    assert len(test) == 20
+    assert len(train) == 0
+
+
+def test_walk_forward_n_splits_one() -> None:
+    folds = walk_forward(50, n_splits=1, expanding=True, embargo=0.0)
+    assert len(folds) == 1
+    train, test = folds[0]
+    assert len(train) > 0
+    assert len(test) > 0
+    assert int(train.max()) < int(test.min())
+
+
+def test_walk_forward_min_train_respected() -> None:
+    folds = walk_forward(100, n_splits=3, expanding=True, min_train=40, embargo=0.0)
+    first_train, _ = folds[0]
+    assert len(first_train) >= 40
+
+
+def test_purged_kfold_invalid_n_splits_raises() -> None:
+    with pytest.raises(ValueError):
+        purged_kfold(10, n_splits=0)
+
+
+def test_walk_forward_invalid_n_splits_raises() -> None:
+    with pytest.raises(ValueError):
+        walk_forward(10, n_splits=0)


### PR DESCRIPTION
Completes the `p2k0` ML surface: bulk leakage-safe feature extraction, López de Prado labels, and purged/embargo cross-validation — built on `df.ta.all()` (p2k0.2) and the existing `build_feature_matrix`. Closes **p2k0.6**.

## `qw.features.extract(df, feature_sets, by, horizon)` -> (features_df, feature_names, metadata)
Four feature sets: `ta_core` (via `df.ta.all()`), `ehlers` + `regimes` (reusing `features._apply_feature`: hurst/cyber_cycle/griffiths/trendflex/itrend/HMM), and new `rolling_stats` (trailing-window Polars exprs). Per-symbol via `by`. **Leakage-safe by construction** — every feature at time t uses information ≤ t only.

## `qw.features.forward_returns` / `qw.features.triple_barrier`
Forward returns over horizons (tail-null, per-symbol safe) and triple-barrier labels {-1,0,+1} with first-touch semantics, right-closed window, and null for insufficient future data. Verified against hand-constructed gold price paths with known outcomes.

## `qw.features.purged_kfold` / `qw.features.walk_forward`
Purged K-fold with `t1`-aware label-span purging + embargo, and expanding/rolling walk-forward with an embargo gap. Pure numpy; zero train/test overlap property-tested.

## Independent verification (not just the agents' own tests)
- **Leakage**: mutated every row after index t by ×1e6, recomputed all four feature sets — **192 feature columns, 0 changed at rows ≤ t**.
- **End-to-end**: extract (192 features) → triple_barrier (labels -1:99 / 0:264 / +1:27) → purged_kfold (5 folds, **0 train/test overlap**).
- **No-deps core install**: the pre-push/CI wheel smoke test caught `feature_splits`'s top-level `import numpy` breaking `import quantwave` on a bare core wheel (no numpy/polars); fixed by guarding the re-export block like the other optional submodules. Both install paths now verified.

## Verification
- Python suite: **296 passed, 1 skipped** (sklearn integration smoke skips cleanly — absent here; 231 → 296)
- Full sanity gate green; wheel smoke passes on a bare no-deps venv

## Notes / follow-ups
- Triple-barrier uses Python loops over `.to_list()` (correctness/auditability over throughput) — a Rust/vectorized rewrite is a reasonable later optimization for tick-scale data.
- `sklearn`/`lightgbm` aren't in the dev env, so the model-fit integration test is `importorskip`-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)