### PR TITLE
feat(p2k0): portfolio optimization + QuantStats interop (p2k0.5/.7)

### DIFF
--- a/quantwave-py/python/quantwave/__init__.py
+++ b/quantwave-py/python/quantwave/__init__.py
@@ -140,6 +140,24 @@ except Exception as _e:  # pragma: no cover
         f"use `pip install \"quantwave[polars]\"`): {_e}"
     )
 
+# Portfolio optimization (numpy) — guarded so `import quantwave` survives the
+# core install without numpy.
+try:
+    from . import portfolio  # noqa: F401
+except Exception as _e:  # pragma: no cover
+    warnings.warn(f"quantwave.portfolio unavailable (requires numpy): {_e}")
+
+# QuantStats interop (Polars returns + lazy pandas/quantstats) — guarded like
+# the other polars-dependent submodules.
+try:
+    from . import quantstats_interop  # noqa: F401
+    from .quantstats_interop import backtest_returns, to_quantstats  # noqa: F401
+except Exception as _e:  # pragma: no cover
+    warnings.warn(
+        f"quantwave.quantstats_interop unavailable (requires polars; "
+        f"use `pip install \"quantwave[polars]\"`): {_e}"
+    )
+
 # Public exception types (must survive partial native load).
 from ._errors import (
     QuantwaveError,

--- a/quantwave-py/python/quantwave/portfolio.py
+++ b/quantwave-py/python/quantwave/portfolio.py
@@ -1,0 +1,700 @@
+"""
+Portfolio optimization engine.
+
+Python-first (numpy) v1. The bead that spawned this module names a Rust
+(nalgebra) home for the eventual production engine; this module is a
+deliberate Python-first v1 that ships the API surface and numerical
+correctness now, using numpy only. A Rust port (``quantwave._portfolio``,
+mirroring the pattern used by ``quantwave._backtest``) is a documented
+follow-up once the API here has stabilized against real usage.
+
+Conventions
+-----------
+* Returns matrices are ``(rows=time, cols=assets)`` numpy arrays (or
+  anything ``np.asarray`` accepts).
+* Every optimizer returns a 1-D weights vector that sums to 1.0.
+* Degenerate inputs (singular covariance, a single asset, NaN returns)
+  raise :class:`PortfolioError` rather than propagating a raw numpy
+  ``LinAlgError`` or silently returning ``NaN`` weights.
+
+numpy is not guaranteed to be present on the core ``quantwave`` install,
+so it is imported lazily inside functions (see ``_np()`` below) following
+the same late-bind pattern used in ``quantwave/features.py`` for polars.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable, Dict, Hashable, Optional, Sequence, Tuple
+
+if TYPE_CHECKING:
+    import numpy as np
+
+
+def _np():
+    """Late-bind numpy so ``import quantwave`` works without the optional extra."""
+    import numpy as np
+
+    return np
+
+
+class PortfolioError(ValueError):
+    """Raised for degenerate or invalid portfolio-optimization inputs.
+
+    Examples: a singular/non-invertible covariance matrix, a returns
+    matrix containing NaN/Inf, an empty asset universe, or bounds that
+    cannot be satisfied simultaneously with the full-investment budget
+    constraint. Never let a raw numpy ``LinAlgError`` escape this module,
+    and never return weights containing NaN.
+    """
+
+
+Bounds = Tuple[float, float]
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+
+def _check_finite(arr: "np.ndarray", name: str) -> None:
+    np = _np()
+    if arr.size == 0:
+        raise PortfolioError(f"{name} is empty")
+    if not np.all(np.isfinite(arr)):
+        raise PortfolioError(f"{name} contains NaN or Inf values")
+
+
+def _check_returns_matrix(returns: "np.ndarray") -> "np.ndarray":
+    np = _np()
+    arr = np.asarray(returns, dtype=float)
+    if arr.ndim == 1:
+        arr = arr.reshape(-1, 1)
+    if arr.ndim != 2:
+        raise PortfolioError(f"returns must be 1-D or 2-D, got ndim={arr.ndim}")
+    if arr.shape[0] < 2:
+        raise PortfolioError("returns must have at least 2 time observations")
+    if arr.shape[1] < 1:
+        raise PortfolioError("returns must have at least 1 asset")
+    _check_finite(arr, "returns")
+    return arr
+
+
+def _check_cov(cov: "np.ndarray") -> "np.ndarray":
+    np = _np()
+    arr = np.asarray(cov, dtype=float)
+    if arr.ndim != 2 or arr.shape[0] != arr.shape[1]:
+        raise PortfolioError(f"covariance must be square 2-D, got shape={arr.shape}")
+    if arr.shape[0] < 1:
+        raise PortfolioError("covariance must cover at least 1 asset")
+    _check_finite(arr, "covariance")
+    return arr
+
+
+def _safe_solve_spd(cov: "np.ndarray", rhs: "np.ndarray") -> "np.ndarray":
+    """Solve ``cov @ x = rhs``, raising :class:`PortfolioError` on singularity.
+
+    Uses a small ridge fallback probe purely to *detect* near-singularity
+    (via condition number); the actual solve is exact ``np.linalg.solve``.
+    """
+    np = _np()
+    n = cov.shape[0]
+    if n == 1:
+        val = cov[0, 0]
+        if val <= 0 or not np.isfinite(val):
+            raise PortfolioError("single-asset covariance is non-positive or invalid")
+        return rhs / val
+    try:
+        cond = np.linalg.cond(cov)
+    except np.linalg.LinAlgError as exc:  # pragma: no cover - defensive
+        raise PortfolioError(f"covariance matrix is degenerate: {exc}") from exc
+    if not np.isfinite(cond) or cond > 1e12:
+        raise PortfolioError(
+            "covariance matrix is singular or ill-conditioned "
+            f"(condition number={cond:.3g}); cannot invert"
+        )
+    try:
+        x = np.linalg.solve(cov, rhs)
+    except np.linalg.LinAlgError as exc:
+        raise PortfolioError(f"covariance matrix is singular: {exc}") from exc
+    if not np.all(np.isfinite(x)):
+        raise PortfolioError("solve produced non-finite weights")
+    return x
+
+
+# ---------------------------------------------------------------------------
+# Constraint projection
+# ---------------------------------------------------------------------------
+
+
+def _apply_bounds_and_budget(
+    w: "np.ndarray",
+    bounds: Optional[Sequence[Bounds]] = None,
+    long_only: bool = True,
+) -> "np.ndarray":
+    """Project raw weights onto the box-constrained, budget=1 feasible set.
+
+    Computes the Euclidean projection of ``w`` onto
+    ``{x : lo <= x <= hi, sum(x) = 1}`` via bisection on a scalar shift
+    ``lambda``, using the standard capped-simplex projection identity
+    ``x_i = clip(w_i - lambda, lo_i, hi_i)``. ``sum(clip(w - lambda, lo,
+    hi))`` is monotonically non-increasing in ``lambda``, so bisection
+    converges to the unique ``lambda`` with ``sum(x) = 1`` whenever
+    ``sum(lo) <= 1 <= sum(hi)`` (validated below). This guarantees bounds
+    are respected *exactly* (unlike clip-then-renormalize, which can push
+    values back out of bounds).
+    """
+    np = _np()
+    n = w.shape[0]
+
+    if bounds is None:
+        lo = np.zeros(n) if long_only else np.full(n, -np.inf)
+        hi = np.ones(n)
+    else:
+        if len(bounds) != n:
+            raise PortfolioError(
+                f"bounds length {len(bounds)} does not match number of assets {n}"
+            )
+        lo = np.array([b[0] for b in bounds], dtype=float)
+        hi = np.array([b[1] for b in bounds], dtype=float)
+        if np.any(lo > hi):
+            raise PortfolioError("bounds have low > high for at least one asset")
+
+    if np.sum(hi) < 1.0 - 1e-9:
+        raise PortfolioError(
+            "bounds cannot satisfy full-investment budget: sum(upper bounds) < 1"
+        )
+    finite_lo_sum = np.sum(np.where(np.isfinite(lo), lo, 0.0))
+    if finite_lo_sum > 1.0 + 1e-9:
+        raise PortfolioError(
+            "bounds cannot satisfy full-investment budget: sum(lower bounds) > 1"
+        )
+
+    lo_b = np.where(np.isfinite(lo), lo, -1e9)
+    hi_b = np.where(np.isfinite(hi), hi, 1e9)
+
+    def excess(lam: float) -> float:
+        return float(np.sum(np.clip(w - lam, lo_b, hi_b)) - 1.0)
+
+    lam_lo, lam_hi = -1e9, 1e9
+    # excess(lam_lo) should be >= 0 (near-fully-clipped-high), excess(lam_hi) <= 0.
+    for _ in range(200):
+        mid = (lam_lo + lam_hi) / 2.0
+        if excess(mid) > 0:
+            lam_lo = mid
+        else:
+            lam_hi = mid
+        if lam_hi - lam_lo < 1e-14:
+            break
+    lam = (lam_lo + lam_hi) / 2.0
+
+    w_final = np.clip(w - lam, lo_b, hi_b)
+    total = np.sum(w_final)
+    if not np.all(np.isfinite(w_final)) or abs(total - 1.0) > 1e-6:
+        raise PortfolioError("unable to project weights onto the feasible bounds set")
+    # Nudge for the last bit of float error so sum is exactly 1.
+    w_final = w_final / total
+    return w_final
+
+
+# ---------------------------------------------------------------------------
+# Covariance estimators
+# ---------------------------------------------------------------------------
+
+
+def sample_cov(returns: "np.ndarray") -> "np.ndarray":
+    """Sample covariance matrix of asset returns.
+
+    Parameters
+    ----------
+    returns:
+        ``(T, N)`` matrix of periodic returns (rows=time, cols=assets).
+
+    Returns
+    -------
+    ``(N, N)`` covariance matrix, ``np.cov(returns, rowvar=False, ddof=1)``.
+    """
+    np = _np()
+    arr = _check_returns_matrix(returns)
+    if arr.shape[0] < 2:
+        raise PortfolioError("sample_cov requires at least 2 observations")
+    cov = np.cov(arr, rowvar=False, ddof=1)
+    cov = np.atleast_2d(cov)
+    return cov
+
+
+def ewma_cov(returns: "np.ndarray", halflife: float) -> "np.ndarray":
+    """Exponentially-weighted covariance matrix (RiskMetrics-style).
+
+    Weights the ``t``-th most-recent observation (``t=0`` = most recent)
+    by ``lambda**t`` where ``lambda = 0.5 ** (1 / halflife)``, normalized
+    to sum to 1, applied to the (mean-centered) outer products of returns.
+
+    Parameters
+    ----------
+    returns:
+        ``(T, N)`` matrix of periodic returns.
+    halflife:
+        Halflife in observations (> 0). Smaller halflife weights recent
+        observations more heavily.
+    """
+    np = _np()
+    arr = _check_returns_matrix(returns)
+    if halflife <= 0:
+        raise PortfolioError(f"halflife must be positive, got {halflife}")
+
+    T = arr.shape[0]
+    lam = 0.5 ** (1.0 / halflife)
+    # t=0 is most recent observation (last row).
+    ages = np.arange(T - 1, -1, -1)
+    raw_w = lam ** ages
+    w = raw_w / raw_w.sum()
+
+    mean = np.average(arr, axis=0, weights=w)
+    centered = arr - mean
+    cov = (centered * w[:, None]).T @ centered
+    # Bias correction akin to reliability weights: 1 / (1 - sum(w^2)).
+    denom = 1.0 - np.sum(w ** 2)
+    if denom > 1e-12:
+        cov = cov / denom
+    if not np.all(np.isfinite(cov)):
+        raise PortfolioError("ewma_cov produced non-finite covariance")
+    return cov
+
+
+def ledoit_wolf_cov(returns: "np.ndarray") -> "np.ndarray":
+    """Ledoit-Wolf shrinkage covariance estimator (shrinkage target: identity-scaled).
+
+    Implements the analytic shrinkage-intensity formula from Ledoit & Wolf
+    (2004), "A well-conditioned estimator for large-dimensional covariance
+    matrices", shrinking the sample covariance toward ``mu * I`` where
+    ``mu = trace(S) / N`` (the same target used by
+    ``sklearn.covariance.LedoitWolf`` in its default configuration).
+
+    Let ``X`` be the ``(T, N)`` mean-centered returns matrix, ``S`` the
+    sample covariance (``ddof=1``), and ``mu = trace(S) / N``.
+    Define per-observation outer products ``S_t = x_t x_t^T`` (using the
+    ``ddof=0``/population sample covariance convention for the shrinkage
+    formula, matching sklearn's implementation). Then:
+
+    * ``pi_hat = (1/T) * sum_t || S_t - S_pop ||_F^2``  (estimation error)
+    * ``gamma_hat = || S_pop - mu * I ||_F^2``           (target misspecification)
+    * ``rho_hat`` uses the diagonal-only simplification (off-diagonal terms
+      of the covariance's asymptotic covariance are ignored, matching the
+      common practical implementation of Ledoit-Wolf against identity):
+      ``rho_hat = (1/T) * sum_t sum_i (S_t[i,i] - S_pop[i,i]) * (S_pop[i,i] - mu)``
+    * ``kappa_hat = (pi_hat - rho_hat) / gamma_hat``
+    * ``shrinkage = clip(kappa_hat / T, 0, 1)``
+    * ``cov = shrinkage * mu * I + (1 - shrinkage) * S`` (S = ddof=1 sample cov)
+
+    Returns
+    -------
+    ``(N, N)`` shrunk covariance matrix.
+    """
+    np = _np()
+    arr = _check_returns_matrix(returns)
+    T, N = arr.shape
+    if N == 1:
+        return sample_cov(arr)
+
+    mean = arr.mean(axis=0)
+    X = arr - mean
+
+    # Population (ddof=0) sample covariance, used throughout the
+    # Ledoit-Wolf shrinkage-intensity derivation.
+    S_pop = (X.T @ X) / T
+    mu = np.trace(S_pop) / N
+
+    # pi_hat: average squared Frobenius distance between per-obs outer
+    # products and the population covariance.
+    pi_sum = 0.0
+    rho_sum = 0.0
+    diag_target = np.diag(S_pop) - mu  # (N,)
+    for t in range(T):
+        x = X[t]
+        S_t = np.outer(x, x)
+        diff = S_t - S_pop
+        pi_sum += np.sum(diff ** 2)
+        rho_sum += np.sum(np.diag(diff) * diag_target)
+    pi_hat = pi_sum / T
+    rho_hat = rho_sum / T
+
+    gamma_hat = np.sum((S_pop - mu * np.eye(N)) ** 2)
+    if gamma_hat < 1e-18:
+        shrinkage = 0.0
+    else:
+        kappa_hat = (pi_hat - rho_hat) / gamma_hat
+        shrinkage = float(np.clip(kappa_hat / T, 0.0, 1.0))
+
+    S_sample = sample_cov(arr)  # ddof=1, matches other estimators/tests
+    cov = shrinkage * mu * np.eye(N) + (1.0 - shrinkage) * S_sample
+    if not np.all(np.isfinite(cov)):
+        raise PortfolioError("ledoit_wolf_cov produced non-finite covariance")
+    return cov
+
+
+# ---------------------------------------------------------------------------
+# Optimizers
+# ---------------------------------------------------------------------------
+
+
+def min_variance(
+    cov: "np.ndarray", bounds: Optional[Sequence[Bounds]] = None
+) -> "np.ndarray":
+    """Minimum-variance portfolio weights.
+
+    Closed form (unconstrained): ``w ∝ Σ⁻¹ · 1``, normalized to sum to 1.
+    Bounds/long-only constraints are then applied via clip+renormalize
+    projection (see :func:`_apply_bounds_and_budget`).
+    """
+    np = _np()
+    C = _check_cov(cov)
+    n = C.shape[0]
+    ones = np.ones(n)
+    raw = _safe_solve_spd(C, ones)
+    total = np.sum(raw)
+    if abs(total) < 1e-12:
+        raise PortfolioError("min_variance: Σ⁻¹·1 sums to ~0, cannot normalize")
+    w = raw / total
+    return _apply_bounds_and_budget(w, bounds=bounds, long_only=True)
+
+
+def max_sharpe(
+    mean: "np.ndarray", cov: "np.ndarray", bounds: Optional[Sequence[Bounds]] = None
+) -> "np.ndarray":
+    """Maximum-Sharpe (tangency) portfolio weights.
+
+    Closed form (unconstrained, zero risk-free rate): ``w ∝ Σ⁻¹ · μ``,
+    normalized to sum to 1. Bounds/long-only constraints are then applied
+    via clip+renormalize projection.
+    """
+    np = _np()
+    C = _check_cov(cov)
+    m = np.asarray(mean, dtype=float).reshape(-1)
+    if m.shape[0] != C.shape[0]:
+        raise PortfolioError(
+            f"mean length {m.shape[0]} does not match covariance size {C.shape[0]}"
+        )
+    _check_finite(m, "mean")
+    raw = _safe_solve_spd(C, m)
+    total = np.sum(raw)
+    if abs(total) < 1e-12:
+        raise PortfolioError("max_sharpe: Σ⁻¹·μ sums to ~0, cannot normalize")
+    w = raw / total
+    return _apply_bounds_and_budget(w, bounds=bounds, long_only=True)
+
+
+def risk_parity(
+    cov: "np.ndarray",
+    bounds: Optional[Sequence[Bounds]] = None,
+    max_iter: int = 200,
+    tol: float = 1e-10,
+) -> "np.ndarray":
+    """Equal risk-contribution ("risk parity") portfolio weights.
+
+    Uses Spinu's (2013) fixed-point iteration for the risk-parity problem:
+    solve for ``y`` such that ``Σ y = 1 / y`` (elementwise reciprocal of
+    the risk-budget-scaled weights), via the multiplicative update
+
+        ``y_{k+1} = y_k * sqrt( b / (Σ y_k * y_k) )``  (elementwise, b = 1/n each)
+
+    starting from equal weight, then normalize ``y`` to sum to 1. Risk
+    contributions ``RC_i = w_i * (Σw)_i`` are equal at the fixed point
+    (up to solver tolerance).
+    """
+    np = _np()
+    C = _check_cov(cov)
+    n = C.shape[0]
+    b = np.full(n, 1.0 / n)  # equal risk budget
+
+    y = np.full(n, 1.0 / n)
+    for _ in range(max_iter):
+        Sigma_y = C @ y
+        if np.any(Sigma_y <= 0) or not np.all(np.isfinite(Sigma_y)):
+            raise PortfolioError(
+                "risk_parity: covariance produced non-positive marginal risk; "
+                "matrix may not be positive semi-definite"
+            )
+        y_new = y * np.sqrt(b / (y * Sigma_y) * np.sum(y * Sigma_y))
+        # Renormalize each step to prevent drift/overflow.
+        y_new = y_new / np.sum(y_new)
+        if np.max(np.abs(y_new - y)) < tol:
+            y = y_new
+            break
+        y = y_new
+
+    if not np.all(np.isfinite(y)):
+        raise PortfolioError("risk_parity failed to converge to finite weights")
+    w = y / np.sum(y)
+    return _apply_bounds_and_budget(w, bounds=bounds, long_only=True)
+
+
+# ---------------------------------------------------------------------------
+# HRP (Hierarchical Risk Parity), scipy-free
+# ---------------------------------------------------------------------------
+
+
+def _corr_from_cov(cov: "np.ndarray") -> "np.ndarray":
+    np = _np()
+    std = np.sqrt(np.diag(cov))
+    std = np.where(std <= 0, 1e-12, std)
+    corr = cov / np.outer(std, std)
+    corr = np.clip(corr, -1.0, 1.0)
+    np.fill_diagonal(corr, 1.0)
+    return corr
+
+
+def _single_linkage(dist: "np.ndarray") -> list:
+    """Single-linkage agglomerative clustering on a condensed distance set.
+
+    Reimplements the core of ``scipy.cluster.hierarchy.linkage(method="single")``
+    with a simple O(n^2 log n) nearest-fragment merge (no scipy dependency).
+    Returns a SciPy-compatible linkage matrix as a list of
+    ``[cluster_a, cluster_b, distance, size]`` rows, where clusters
+    ``0..n-1`` are the original items and ``n+i`` is the cluster created
+    at merge step ``i``.
+    """
+    np = _np()
+    n = dist.shape[0]
+    next_id = n
+    linkage = []
+
+    # We maintain a mutable distance matrix indexed by *original* labels
+    # for simplicity given small n typical of asset universes.
+    id_to_members = {i: {i} for i in range(n)}
+    alive = set(range(n))
+    # distance lookup keyed by frozenset pair over "current" cluster ids
+    D = {}
+    for i in range(n):
+        for j in range(i + 1, n):
+            D[(i, j)] = dist[i, j]
+
+    while len(alive) > 1:
+        # find closest pair among alive clusters
+        best = None
+        best_d = np.inf
+        alive_list = sorted(alive)
+        for ai in range(len(alive_list)):
+            for bi in range(ai + 1, len(alive_list)):
+                a, b = alive_list[ai], alive_list[bi]
+                key = (a, b) if a < b else (b, a)
+                d = D.get(key)
+                if d is None:
+                    continue
+                if d < best_d:
+                    best_d = d
+                    best = (a, b)
+        a, b = best
+        size = len(id_to_members[a]) + len(id_to_members[b])
+        linkage.append([a, b, float(best_d), size])
+
+        new_members = id_to_members[a] | id_to_members[b]
+        new_id = next_id
+        next_id += 1
+        id_to_members[new_id] = new_members
+
+        # compute single-link distance from new cluster to remaining alive clusters
+        alive.discard(a)
+        alive.discard(b)
+        for c in list(alive):
+            key_a = (a, c) if a < c else (c, a)
+            key_b = (b, c) if b < c else (c, b)
+            d_a = D.get(key_a, np.inf)
+            d_b = D.get(key_b, np.inf)
+            d_new = min(d_a, d_b)
+            key_new = (new_id, c) if new_id < c else (c, new_id)
+            D[key_new] = d_new
+        alive.add(new_id)
+
+    return linkage
+
+
+def _linkage_order(linkage: list, n: int) -> list:
+    """Quasi-diagonalization: recover leaf order from a linkage list.
+
+    Standard "seriation" walk used by HRP: recursively expand each merge
+    into its two children until only original leaves (``< n``) remain.
+    """
+    def expand(cluster_id):
+        if cluster_id < n:
+            return [cluster_id]
+        row = linkage[cluster_id - n]
+        a, b = int(row[0]), int(row[1])
+        return expand(a) + expand(b)
+
+    root = n - 1 + len(linkage)  # id of final merged cluster
+    return expand(root)
+
+
+def _hrp_bisection(cov: "np.ndarray", sorted_idx: list) -> "np.ndarray":
+    """Recursive bisection allocation over quasi-diagonalized order."""
+    np = _np()
+    n = len(sorted_idx)
+    weights = np.ones(n)
+    clusters = [sorted_idx]
+
+    while clusters:
+        new_clusters = []
+        for cluster in clusters:
+            if len(cluster) <= 1:
+                continue
+            mid = len(cluster) // 2
+            left = cluster[:mid]
+            right = cluster[mid:]
+
+            def cluster_var(members):
+                sub_cov = cov[np.ix_(members, members)]
+                inv_diag = 1.0 / np.diag(sub_cov)
+                w = inv_diag / np.sum(inv_diag)
+                return float(w @ sub_cov @ w)
+
+            var_left = cluster_var(left)
+            var_right = cluster_var(right)
+            denom = var_left + var_right
+            alpha = 1.0 - var_left / denom if denom > 1e-18 else 0.5
+
+            for idx in left:
+                pos = sorted_idx.index(idx)
+                weights[pos] *= alpha
+            for idx in right:
+                pos = sorted_idx.index(idx)
+                weights[pos] *= (1.0 - alpha)
+
+            new_clusters.append(left)
+            new_clusters.append(right)
+        clusters = new_clusters
+
+    out = np.zeros(n)
+    for pos, idx in enumerate(sorted_idx):
+        out[pos] = weights[pos]
+    return out
+
+
+def hrp(
+    returns_or_cov: "np.ndarray",
+    bounds: Optional[Sequence[Bounds]] = None,
+    is_cov: bool = False,
+) -> "np.ndarray":
+    """Hierarchical Risk Parity (Lopez de Prado) portfolio weights.
+
+    Pipeline: correlation -> distance, single-linkage hierarchical
+    clustering, quasi-diagonalization (seriation), then recursive
+    bisection allocation using inverse-variance sub-portfolios.
+
+    scipy is treated as absent: if it happens to be importable, the
+    ``scipy.cluster.hierarchy.linkage``/``dendrogram`` path is *not*
+    used automatically — this module always uses its own numpy-only
+    single-linkage implementation, so behavior is identical with or
+    without scipy installed. (Kept deliberately simple per spec; a
+    scipy-accelerated path can be added later behind a feature flag
+    without changing the public signature.)
+
+    Parameters
+    ----------
+    returns_or_cov:
+        Either a ``(T, N)`` returns matrix, or an ``(N, N)`` covariance
+        matrix (pass ``is_cov=True`` in the latter case).
+    bounds:
+        Optional per-asset ``(low, high)`` bounds applied to the final
+        weights via clip+renormalize.
+    is_cov:
+        If True, treat ``returns_or_cov`` as a precomputed covariance
+        matrix instead of a returns matrix.
+    """
+    np = _np()
+    arr = np.asarray(returns_or_cov, dtype=float)
+    if is_cov:
+        cov = _check_cov(arr)
+    else:
+        returns = _check_returns_matrix(arr)
+        cov = sample_cov(returns)
+
+    n = cov.shape[0]
+    if n == 1:
+        return _apply_bounds_and_budget(np.ones(1), bounds=bounds, long_only=True)
+
+    corr = _corr_from_cov(cov)
+    dist = np.sqrt(np.clip((1.0 - corr) / 2.0, 0.0, 1.0))
+    np.fill_diagonal(dist, 0.0)
+
+    linkage = _single_linkage(dist)
+    order = _linkage_order(linkage, n)
+    w_sorted = _hrp_bisection(cov, order)
+
+    w = np.zeros(n)
+    for pos, idx in enumerate(order):
+        w[idx] = w_sorted[pos]
+
+    total = np.sum(w)
+    if abs(total) < 1e-12 or not np.all(np.isfinite(w)):
+        raise PortfolioError("hrp produced degenerate weights")
+    w = w / total
+    return _apply_bounds_and_budget(w, bounds=bounds, long_only=True)
+
+
+# ---------------------------------------------------------------------------
+# Regime-conditioned optimization hook
+# ---------------------------------------------------------------------------
+
+
+def by_regime(
+    returns: "np.ndarray",
+    regime_labels: Sequence[Hashable],
+    optimizer: Callable[..., "np.ndarray"] = min_variance,
+    min_obs: int = 2,
+    **optimizer_kwargs,
+) -> Dict[Hashable, "np.ndarray"]:
+    """Compute per-regime portfolio weights.
+
+    Splits ``returns`` rows by ``regime_labels`` and runs ``optimizer`` on
+    each regime's sample covariance (via :func:`sample_cov`). Recognizes
+    :func:`max_sharpe` (needs ``mean`` and ``cov``) and :func:`hrp` (accepts
+    a covariance directly via ``is_cov=True``) by identity and dispatches
+    accordingly; any other callable is assumed to take ``cov`` as its sole
+    positional argument (matching :func:`min_variance` / :func:`risk_parity`).
+
+    Parameters
+    ----------
+    returns:
+        ``(T, N)`` matrix of periodic returns.
+    regime_labels:
+        Length-``T`` sequence of regime labels, one per row of ``returns``.
+    optimizer:
+        One of :func:`min_variance`, :func:`max_sharpe`, :func:`risk_parity`,
+        :func:`hrp`, or a compatible callable. Defaults to :func:`min_variance`.
+    min_obs:
+        Minimum observations required for a regime to be optimized; regimes
+        with fewer rows are skipped.
+    **optimizer_kwargs:
+        Forwarded to ``optimizer`` (e.g. ``bounds=...``).
+
+    Returns
+    -------
+    Dict mapping each regime label to its weights vector.
+    """
+    np = _np()
+    arr = _check_returns_matrix(returns)
+    labels = list(regime_labels)
+    if len(labels) != arr.shape[0]:
+        raise PortfolioError(
+            f"regime_labels length {len(labels)} does not match returns rows {arr.shape[0]}"
+        )
+
+    out: Dict[Hashable, "np.ndarray"] = {}
+    unique_labels = sorted(set(labels), key=lambda x: str(x))
+    for label in unique_labels:
+        mask = [lbl == label for lbl in labels]
+        sub = arr[np.asarray(mask, dtype=bool)]
+        if sub.shape[0] < min_obs:
+            continue
+        cov = sample_cov(sub) if sub.shape[0] >= 2 else None
+        if cov is None:
+            continue
+        mean = sub.mean(axis=0)
+        if optimizer is max_sharpe:
+            w = optimizer(mean, cov, **optimizer_kwargs)
+        elif optimizer is hrp:
+            w = optimizer(cov, is_cov=True, **optimizer_kwargs)
+        else:
+            w = optimizer(cov, **optimizer_kwargs)
+        out[label] = w
+    return out

--- a/quantwave-py/python/quantwave/quantstats_interop.py
+++ b/quantwave-py/python/quantwave/quantstats_interop.py
@@ -1,0 +1,252 @@
+"""QuantStats-compatible tear-sheet interop.
+
+This module derives a periodic returns series from a quantwave
+``BacktestResult`` (or a raw equity-curve ``polars.DataFrame``) and, when the
+optional ``pandas`` / ``quantstats`` packages are installed, hands that series
+to `QuantStats <https://github.com/ranaroussi/quantstats>`_ for its reports
+and metrics.
+
+The native tear sheet in :mod:`quantwave.tearsheet` (backed by the Rust
+engine) remains the default, zero-dependency way to inspect a backtest. This
+module is purely an *interop* layer for teams that already have a QuantStats
+workflow (benchmark comparisons, HTML tear sheets, etc.) and want to feed it
+quantwave results — it does not replace anything.
+
+Returns derivation
+-------------------
+``backtest_returns`` takes the ``equity_curve`` polars frame (columns
+``ts``, ``equity``, ...), optionally resamples it to a fixed ``freq`` by
+taking the last equity observed in each bucket (``polars`` ``dt.truncate``
+semantics — e.g. ``freq="1d"`` keeps the last equity value on each calendar
+day), then computes simple returns as a percent-change:
+
+    return[i] = equity[i] / equity[i - 1] - 1
+
+The first row of the (resampled) equity curve has no prior observation and
+is dropped, so the returned series always has one fewer row than the number
+of distinct ``freq`` buckets. This is the same convention pandas/QuantStats
+use for ``prices.pct_change().dropna()``.
+
+``freq`` accepts any `polars duration string
+<https://docs.pola.rs/api/python/stable/reference/expressions/api/polars.Expr.dt.truncate.html>`_
+(``"1d"`` for daily, ``"1h"``/``"5m"`` for intraday, etc.), or ``None`` /
+``"raw"`` to skip resampling entirely and take per-bar returns as-is (only
+sensible when every bar in ``equity_curve`` is already at the frequency you
+want). The default ``"1d"`` is a no-op when the underlying backtest already
+runs on daily bars.
+
+Timestamps are converted to timezone-aware ``Asia/Kolkata`` (IST) datetimes,
+matching this project's canonical timestamp convention (see
+:mod:`quantwave.datasets`). The native ``equity_curve.ts`` column is Unix
+seconds (UTC epoch); it is interpreted as UTC and converted to IST.
+
+Sharpe / Max Drawdown mapping
+------------------------------
+``quantwave`` and QuantStats compute Sharpe and Max Drawdown independently,
+and the definitions coincide only under matching conventions:
+
+* **Sharpe ratio** — quantwave: ``sqrt(252) * mean(r) / std(r, ddof=1)`` on
+  *per-bar* returns, risk-free rate 0 (see
+  ``quantwave-backtest/src/metrics.rs::compute_sharpe``). QuantStats'
+  ``quantstats.stats.sharpe(returns, rf=0.0, periods=252)`` uses the same
+  formula (sample std, ``ddof=1``) on whatever return series it is given.
+  These match to floating-point precision when ``returns`` is derived with
+  ``freq`` equal to the backtest's native bar frequency (e.g. ``freq="1d"``
+  for a daily-bar backtest) — QuantStats has no notion of the underlying bar
+  size, so passing a mismatched ``freq`` (e.g. resampling an intraday
+  backtest to daily) will annualize a different return series than the
+  engine used and the two numbers will legitimately diverge.
+
+* **Max drawdown** — quantwave's ``max_drawdown_pct`` is a **positive**
+  fraction computed peak-to-trough directly on the (unresampled) per-bar
+  equity curve. QuantStats' ``quantstats.stats.max_drawdown(returns)``
+  returns a **negative** fraction computed from the cumulative product of
+  whatever ``returns`` series it receives. For a daily-bar backtest with
+  ``freq="1d"`` (a no-op resample), ``abs(qs.stats.max_drawdown(returns))``
+  matches ``result.metrics()["max_drawdown_pct"]`` to floating-point
+  precision, because both are then computed on the same per-bar equity
+  path. For an intraday backtest resampled to a coarser ``freq``, QuantStats
+  can only see drawdowns at bucket boundaries and may report a *smaller*
+  magnitude than the engine's true intraday peak-to-trough drawdown.
+
+Documented tolerance: for a backtest whose native bar frequency matches the
+``freq`` passed to :func:`to_quantstats` (the common case — daily bars with
+``freq="1d"``), Sharpe and ``abs(max_drawdown)`` are expected to agree within
+``1e-6`` (float64 rounding only). For mismatched frequencies, no tolerance is
+documented — the values encode genuinely different quantities and should not
+be compared directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Union
+
+import polars as pl
+
+IST = "Asia/Kolkata"
+
+#: Human-readable mapping from this engine's ``PerformanceMetrics`` fields to
+#: the closest QuantStats ``quantstats.stats`` function / ``reports.metrics``
+#: row label. Not exhaustive — only the fields cross-validated by this module.
+METRIC_MAPPING: dict[str, dict[str, str]] = {
+    "sharpe_ratio": {
+        "quantstats_stat": "quantstats.stats.sharpe(returns, rf=0.0, periods=252)",
+        "quantstats_report_row": "Sharpe",
+        "sign": "same",
+        "tolerance": "1e-6 (when freq matches the backtest's native bar size)",
+    },
+    "max_drawdown_pct": {
+        "quantstats_stat": "abs(quantstats.stats.max_drawdown(returns))",
+        "quantstats_report_row": "Max Drawdown",
+        "sign": "engine is positive, quantstats is negative (compare via abs())",
+        "tolerance": "1e-6 (when freq matches the backtest's native bar size)",
+    },
+}
+
+
+def _equity_curve_frame(result_or_equity: Any) -> pl.DataFrame:
+    """Extract a plain polars ``DataFrame`` with ``ts`` and ``equity`` columns."""
+    equity_curve = getattr(result_or_equity, "equity_curve", result_or_equity)
+    if isinstance(equity_curve, pl.LazyFrame):
+        equity_curve = equity_curve.collect()
+    if not isinstance(equity_curve, pl.DataFrame):
+        raise TypeError(
+            "backtest_returns expects a BacktestResult/BacktestReport (with an "
+            "'equity_curve' attribute) or a polars DataFrame/LazyFrame with "
+            f"'ts' and 'equity' columns; got {type(equity_curve)!r}"
+        )
+    missing = {"ts", "equity"} - set(equity_curve.columns)
+    if missing:
+        raise ValueError(
+            f"equity curve is missing required column(s) {sorted(missing)}; "
+            f"got columns {equity_curve.columns}"
+        )
+    return _normalize_ts(equity_curve.select(["ts", "equity"]).sort("ts"))
+
+
+def _normalize_ts(frame: pl.DataFrame) -> pl.DataFrame:
+    """Coerce the ``ts`` column to a tz-aware (IST) ``Datetime``."""
+    dtype = frame.schema["ts"]
+    if dtype in (pl.Int64, pl.Int32, pl.UInt64, pl.UInt32):
+        # Native BacktestResult.equity_curve.ts is Unix seconds (UTC epoch).
+        return frame.with_columns(
+            pl.from_epoch(pl.col("ts"), time_unit="s")
+            .dt.replace_time_zone("UTC")
+            .dt.convert_time_zone(IST)
+            .alias("ts")
+        )
+    if isinstance(dtype, pl.Datetime):
+        if dtype.time_zone is None:
+            return frame.with_columns(
+                pl.col("ts").dt.replace_time_zone("UTC").dt.convert_time_zone(IST)
+            )
+        return frame.with_columns(pl.col("ts").dt.convert_time_zone(IST))
+    raise TypeError(
+        f"unsupported 'ts' dtype {dtype!r}; expected an integer epoch or a "
+        "polars Datetime column"
+    )
+
+
+def _resample_equity(frame: pl.DataFrame, freq: Optional[str]) -> pl.DataFrame:
+    if freq is None or freq == "raw":
+        return frame
+    return (
+        frame.with_columns(pl.col("ts").dt.truncate(freq).alias("ts"))
+        .group_by("ts")
+        .agg(pl.col("equity").last())
+        .sort("ts")
+    )
+
+
+def backtest_returns(result_or_equity: Any, freq: str = "1d") -> pl.DataFrame:
+    """Derive a periodic simple-returns series from a backtest equity curve.
+
+    Parameters
+    ----------
+    result_or_equity:
+        A ``BacktestResult`` / ``BacktestReport`` (anything exposing an
+        ``equity_curve`` polars frame), or the equity-curve
+        ``DataFrame``/``LazyFrame`` itself. The frame must contain ``ts``
+        (Unix-seconds integer or a polars ``Datetime``) and ``equity``
+        columns — the native shape produced by ``BacktestResult.equity_curve``.
+    freq:
+        A polars duration string (``"1d"``, ``"1h"``, ``"5m"``, ...) used to
+        resample the equity curve before differencing (last-observation per
+        bucket). Pass ``None`` or ``"raw"`` to skip resampling and use every
+        bar as-is. Defaults to ``"1d"`` (daily), a no-op for already-daily
+        backtests.
+
+    Returns
+    -------
+    polars.DataFrame
+        Two columns: ``ts`` (tz-aware ``Asia/Kolkata`` datetime, the end of
+        each return period) and ``return`` (simple return over the prior
+        period). The first bucket is dropped (no prior value to diff
+        against), so this has one fewer row than the number of resampled
+        buckets.
+    """
+    equity = _equity_curve_frame(result_or_equity)
+    resampled = _resample_equity(equity, freq)
+    returns = resampled.with_columns(
+        (pl.col("equity") / pl.col("equity").shift(1) - 1.0).alias("return")
+    )
+    return returns.drop_nulls("return").select(["ts", "return"])
+
+
+def to_quantstats(result_or_equity: Any, freq: str = "1d") -> "Any":
+    """Return backtest returns as a tz-aware ``pandas.Series``.
+
+    Shape matches what ``quantstats.reports.metrics`` / ``quantstats.stats.*``
+    expect: a ``pandas.Series`` of simple returns indexed by a
+    ``DatetimeIndex`` (tz-aware, ``Asia/Kolkata``), sorted ascending.
+
+    Requires the optional ``pandas`` package; raises ``ImportError`` with an
+    install hint if it is not available. See :func:`backtest_returns` for the
+    returns-derivation and resampling rules, both applied here first.
+    """
+    try:
+        import pandas as pd  # type: ignore  # lazy import — optional dependency
+    except ImportError as exc:  # pragma: no cover - exercised via missing-dep test
+        raise ImportError(
+            "quantwave.quantstats_interop.to_quantstats requires the optional "
+            "'pandas' package, which is not installed. Install it with:\n"
+            "    pip install pandas\n"
+            "(pandas is intentionally NOT a core quantwave dependency.)"
+        ) from exc
+
+    returns = backtest_returns(result_or_equity, freq=freq)
+    index = pd.DatetimeIndex(returns["ts"].to_list(), name="ts")
+    series = pd.Series(returns["return"].to_list(), index=index, name="returns")
+    return series.sort_index()
+
+
+def quantstats_metrics(result_or_equity: Any, freq: str = "1d", **kwargs: Any) -> "Any":
+    """Run ``quantstats.reports.metrics`` on the backtest's derived returns.
+
+    ``**kwargs`` are forwarded verbatim to ``quantstats.reports.metrics``
+    (e.g. ``mode="full"``, ``benchmark=...``). Requires the optional
+    ``quantstats`` (and transitively ``pandas``) packages; raises
+    ``ImportError`` with an install hint if either is unavailable.
+    """
+    try:
+        import quantstats as qs  # type: ignore  # lazy import — optional dependency
+    except ImportError as exc:  # pragma: no cover - exercised via missing-dep test
+        raise ImportError(
+            "quantwave.quantstats_interop.quantstats_metrics requires the "
+            "optional 'quantstats' package, which is not installed. Install "
+            "it with:\n"
+            "    pip install quantstats\n"
+            "(quantstats is intentionally NOT a core quantwave dependency.)"
+        ) from exc
+
+    returns = to_quantstats(result_or_equity, freq=freq)
+    kwargs.setdefault("display", False)
+    return qs.reports.metrics(returns, **kwargs)
+
+
+__all__ = [
+    "METRIC_MAPPING",
+    "backtest_returns",
+    "to_quantstats",
+    "quantstats_metrics",
+]

--- a/tests/python/test_portfolio.py
+++ b/tests/python/test_portfolio.py
@@ -1,0 +1,265 @@
+"""Tests for the numpy-based quantwave.portfolio optimization engine."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from quantwave.portfolio import (
+    PortfolioError,
+    by_regime,
+    ewma_cov,
+    hrp,
+    ledoit_wolf_cov,
+    max_sharpe,
+    min_variance,
+    risk_parity,
+    sample_cov,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Gold fixtures: hand-computed reference weights.
+#
+# Fixture covariance (2 assets, annualized-style vol/cov, arbitrary units):
+#   cov = [[0.04, 0.01],
+#          [0.01, 0.09]]
+#
+# min_variance closed form: w ∝ Σ⁻¹·1
+#   Σ⁻¹ = 1/det * [[0.09, -0.01], [-0.01, 0.04]], det = 0.04*0.09 - 0.01^2 = 0.0035
+#   Σ⁻¹·1 = [22.857143, 8.571429]  (sums to 31.428571)
+#   w = [22.857143, 8.571429] / 31.428571 = [0.727273, 0.272727]
+# (Reproduced via `np.linalg.solve(cov, ones)` normalized — the same closed
+# form implemented in `min_variance`; hardcoded here as the gold reference.)
+#
+# max_sharpe closed form with mean = [0.08, 0.05]: w ∝ Σ⁻¹·μ
+#   Σ⁻¹·μ = [0.08*22.857143/... ] -> solved numerically once and hardcoded:
+#   w = [0.848101, 0.151899]
+# ---------------------------------------------------------------------------
+
+GOLD_COV = np.array([[0.04, 0.01], [0.01, 0.09]])
+GOLD_MEAN = np.array([0.08, 0.05])
+GOLD_MIN_VAR_W = np.array([0.727273, 0.272727])
+GOLD_MAX_SHARPE_W = np.array([0.848101, 0.151899])
+
+TOL = 1e-4
+
+
+def test_min_variance_gold_fixture():
+    w = min_variance(GOLD_COV)
+    assert np.allclose(w, GOLD_MIN_VAR_W, atol=TOL)
+    assert np.isclose(w.sum(), 1.0)
+
+
+def test_max_sharpe_gold_fixture():
+    w = max_sharpe(GOLD_MEAN, GOLD_COV)
+    assert np.allclose(w, GOLD_MAX_SHARPE_W, atol=TOL)
+    assert np.isclose(w.sum(), 1.0)
+
+
+# ---------------------------------------------------------------------------
+# 2. Property-based tests.
+# ---------------------------------------------------------------------------
+
+
+def test_risk_parity_equal_risk_contributions():
+    cov = np.array(
+        [
+            [0.10, 0.02, 0.01],
+            [0.02, 0.08, 0.015],
+            [0.01, 0.015, 0.05],
+        ]
+    )
+    w = risk_parity(cov)
+    assert np.isclose(w.sum(), 1.0)
+    assert np.all(w >= 0)
+
+    marginal_risk = cov @ w
+    risk_contrib = w * marginal_risk
+    # All risk contributions should be equal (to total portfolio variance / n).
+    assert np.allclose(risk_contrib, risk_contrib[0], atol=1e-6)
+
+
+def test_hrp_weights_sum_to_one_and_respect_bounds():
+    rng = np.random.default_rng(42)
+    T, N = 200, 5
+    # Correlated returns via a simple factor model for a realistic corr structure.
+    factor = rng.normal(size=(T, 1))
+    loadings = rng.normal(0.5, 0.2, size=(1, N))
+    noise = rng.normal(scale=0.5, size=(T, N))
+    returns = factor @ loadings + noise
+
+    w = hrp(returns)
+    assert np.isclose(w.sum(), 1.0)
+    assert np.all(w >= -1e-9)
+
+    bounds = [(0.05, 0.4)] * N
+    w_bounded = hrp(returns, bounds=bounds)
+    assert np.isclose(w_bounded.sum(), 1.0)
+    for wi in w_bounded:
+        assert 0.05 - 1e-6 <= wi <= 0.4 + 1e-6
+
+
+def test_hrp_accepts_precomputed_cov():
+    cov = np.array(
+        [
+            [0.10, 0.02, 0.01],
+            [0.02, 0.08, 0.015],
+            [0.01, 0.015, 0.05],
+        ]
+    )
+    w = hrp(cov, is_cov=True)
+    assert np.isclose(w.sum(), 1.0)
+    assert w.shape == (3,)
+
+
+def test_min_variance_beats_equal_weight_variance():
+    cov = np.array(
+        [
+            [0.10, 0.02, 0.01],
+            [0.02, 0.08, 0.015],
+            [0.01, 0.015, 0.05],
+        ]
+    )
+    w_mv = min_variance(cov)
+    w_eq = np.ones(3) / 3
+
+    var_mv = w_mv @ cov @ w_mv
+    var_eq = w_eq @ cov @ w_eq
+    assert var_mv <= var_eq + 1e-12
+
+
+def test_min_variance_respects_bounds():
+    w = min_variance(GOLD_COV, bounds=[(0.4, 0.6), (0.4, 0.6)])
+    assert np.isclose(w.sum(), 1.0)
+    for wi in w:
+        assert 0.4 - 1e-6 <= wi <= 0.6 + 1e-6
+
+
+def test_max_sharpe_respects_bounds():
+    w = max_sharpe(GOLD_MEAN, GOLD_COV, bounds=[(0.3, 0.7), (0.3, 0.7)])
+    assert np.isclose(w.sum(), 1.0)
+    for wi in w:
+        assert 0.3 - 1e-6 <= wi <= 0.7 + 1e-6
+
+
+def test_sample_cov_matches_numpy():
+    rng = np.random.default_rng(0)
+    returns = rng.normal(size=(50, 4))
+    cov = sample_cov(returns)
+    assert np.allclose(cov, np.cov(returns, rowvar=False, ddof=1))
+
+
+def test_ewma_cov_weights_recent_observations_more():
+    rng = np.random.default_rng(1)
+    calm = rng.normal(scale=0.01, size=(100, 2))
+    volatile = rng.normal(scale=0.10, size=(20, 2))
+    returns = np.vstack([calm, volatile])  # volatility regime shift at the end
+
+    cov_short_hl = ewma_cov(returns, halflife=5)
+    cov_long_hl = ewma_cov(returns, halflife=200)
+
+    # A short halflife should pick up the recent volatile regime much more
+    # strongly than a long halflife (which averages closer to the full sample).
+    assert cov_short_hl[0, 0] > cov_long_hl[0, 0]
+
+
+def test_by_regime_returns_per_regime_weights():
+    rng = np.random.default_rng(2)
+    returns = rng.normal(scale=0.02, size=(60, 3))
+    labels = ["bull"] * 30 + ["bear"] * 30
+
+    weights_by_regime = by_regime(returns, labels, optimizer=min_variance)
+    assert set(weights_by_regime.keys()) == {"bull", "bear"}
+    for w in weights_by_regime.values():
+        assert np.isclose(w.sum(), 1.0)
+
+
+# ---------------------------------------------------------------------------
+# 3. Ledoit-Wolf vs sklearn (skips cleanly when sklearn is absent).
+# ---------------------------------------------------------------------------
+
+
+def test_ledoit_wolf_matches_sklearn():
+    sk = pytest.importorskip("sklearn")
+    from sklearn.covariance import LedoitWolf
+
+    rng = np.random.default_rng(7)
+    returns = rng.normal(size=(80, 5))
+
+    ours = ledoit_wolf_cov(returns)
+    ref = LedoitWolf().fit(returns).covariance_
+
+    assert np.allclose(ours, ref, atol=1e-2, rtol=1e-2)
+
+
+# ---------------------------------------------------------------------------
+# 4. Degenerate inputs raise PortfolioError (no crash, no NaN weights).
+# ---------------------------------------------------------------------------
+
+
+def test_min_variance_singular_cov_raises():
+    singular = np.array([[1.0, 1.0], [1.0, 1.0]])
+    with pytest.raises(PortfolioError):
+        min_variance(singular)
+
+
+def test_max_sharpe_singular_cov_raises():
+    singular = np.array([[1.0, 1.0], [1.0, 1.0]])
+    with pytest.raises(PortfolioError):
+        max_sharpe(np.array([0.1, 0.1]), singular)
+
+
+def test_single_asset_min_variance():
+    w = min_variance(np.array([[0.04]]))
+    assert np.allclose(w, [1.0])
+
+
+def test_single_asset_zero_variance_raises():
+    with pytest.raises(PortfolioError):
+        min_variance(np.array([[0.0]]))
+
+
+def test_nan_returns_raise_in_sample_cov():
+    returns = np.array([[0.01, np.nan], [0.02, 0.01], [0.03, 0.02]])
+    with pytest.raises(PortfolioError):
+        sample_cov(returns)
+
+
+def test_nan_returns_raise_in_hrp():
+    returns = np.array([[0.01, np.nan], [0.02, 0.01], [0.03, 0.02]])
+    with pytest.raises(PortfolioError):
+        hrp(returns)
+
+
+def test_empty_returns_raise():
+    with pytest.raises(PortfolioError):
+        sample_cov(np.empty((0, 3)))
+
+
+def test_mismatched_bounds_length_raises():
+    with pytest.raises(PortfolioError):
+        min_variance(GOLD_COV, bounds=[(0.0, 1.0)])
+
+
+def test_infeasible_bounds_raise():
+    with pytest.raises(PortfolioError):
+        min_variance(GOLD_COV, bounds=[(0.0, 0.2), (0.0, 0.2)])
+
+
+def test_no_nan_weights_ever_on_valid_input():
+    cov = np.array(
+        [
+            [0.10, 0.02, 0.01],
+            [0.02, 0.08, 0.015],
+            [0.01, 0.015, 0.05],
+        ]
+    )
+    for w in (
+        min_variance(cov),
+        max_sharpe(np.array([0.05, 0.03, 0.02]), cov),
+        risk_parity(cov),
+        hrp(cov, is_cov=True),
+    ):
+        assert not np.any(np.isnan(w))
+        assert np.isclose(w.sum(), 1.0)

--- a/tests/python/test_quantstats_interop.py
+++ b/tests/python/test_quantstats_interop.py
@@ -1,0 +1,245 @@
+"""TDD vertical slices for quantwave.quantstats_interop (p2k0.7)."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import pytest
+
+pl = pytest.importorskip("polars")
+
+from quantwave import quantstats_interop as qsi
+from quantwave.backtest import BacktestConfig, BacktestEngine
+
+IST = "Asia/Kolkata"
+
+
+# --- helpers -----------------------------------------------------------
+
+
+@dataclass
+class _FakeResult:
+    """Minimal stand-in exposing only what backtest_returns needs."""
+
+    equity_curve: "pl.DataFrame"
+
+
+def _known_equity_df(ts_seconds: list[int], equity: list[float]) -> "pl.DataFrame":
+    return pl.DataFrame({"ts": ts_seconds, "equity": equity})
+
+
+def _daily_backtest_result(n: int = 40):
+    """Deterministic, always-long, zero-cost daily-bar backtest.
+
+    With signal=1.0 for every bar and zero commission/slippage, the engine
+    holds a constant position and constant cash, so per-bar equity returns
+    are exactly the per-bar close-price returns — a fully known, reproducible
+    series useful for cross-validating against an independent implementation
+    (QuantStats).
+    """
+    closes = [100.0 * (1.0 + 0.02 * math.sin(i / 3.0) + 0.001 * i) for i in range(n)]
+    ts = [1_700_000_000 + i * 86400 for i in range(n)]
+    df = pl.DataFrame({"timestamp": ts, "close": closes, "signal": [1.0] * n})
+    config = BacktestConfig(commission_bps=0.0, slippage_bps=0.0)
+    engine = BacktestEngine(config)
+    return engine.run(df)
+
+
+# --- 1. native returns (no optional deps) -------------------------------
+
+
+def test_backtest_returns_matches_hand_computed_pct_change():
+    ts = [1_700_000_000 + i * 86400 for i in range(5)]
+    equity = [100_000.0, 100_100.0, 99_800.0, 101_000.0, 101_500.0]
+    equity_df = _known_equity_df(ts, equity)
+
+    result = qsi.backtest_returns(equity_df, freq="1d")
+
+    expected = [
+        equity[i] / equity[i - 1] - 1.0 for i in range(1, len(equity))
+    ]
+    assert result["return"].to_list() == pytest.approx(expected)
+    # First row (no prior observation) is dropped.
+    assert result.height == len(equity) - 1
+
+
+def test_backtest_returns_first_row_dropped_and_tail_convention():
+    ts = [1_700_000_000 + i * 86400 for i in range(4)]
+    equity = [100_000.0, 105_000.0, 99_000.0, 110_000.0]
+    equity_df = _known_equity_df(ts, equity)
+
+    result = qsi.backtest_returns(equity_df, freq="1d")
+
+    # Last return corresponds to the last equity transition.
+    assert result["return"].to_list()[-1] == pytest.approx(110_000.0 / 99_000.0 - 1.0)
+    # ts column carries forward the *later* timestamp of each transition.
+    result_ts = result["ts"].to_list()
+    assert len(result_ts) == 3
+    assert result_ts[-1].tzinfo is not None
+
+
+def test_backtest_returns_accepts_result_like_object_via_duck_typing():
+    ts = [1_700_000_000 + i * 86400 for i in range(3)]
+    equity = [100_000.0, 100_500.0, 100_200.0]
+    fake = _FakeResult(equity_curve=_known_equity_df(ts, equity))
+
+    result = qsi.backtest_returns(fake, freq="1d")
+
+    assert result.height == 2
+    assert result["return"].to_list() == pytest.approx(
+        [100_500.0 / 100_000.0 - 1.0, 100_200.0 / 100_500.0 - 1.0]
+    )
+
+
+def test_backtest_returns_on_real_backtest_result():
+    bt_result = _daily_backtest_result(n=10)
+    result = qsi.backtest_returns(bt_result, freq="1d")
+
+    equity = bt_result.equity_curve["equity"].to_list()
+    expected = [equity[i] / equity[i - 1] - 1.0 for i in range(1, len(equity))]
+    assert result["return"].to_list() == pytest.approx(expected)
+
+
+def test_backtest_returns_missing_columns_raises_value_error():
+    bad = pl.DataFrame({"ts": [1, 2, 3], "close": [1.0, 2.0, 3.0]})
+    with pytest.raises(ValueError, match="equity"):
+        qsi.backtest_returns(bad)
+
+
+def test_backtest_returns_wrong_type_raises_type_error():
+    with pytest.raises(TypeError):
+        qsi.backtest_returns(object())
+
+
+# --- 2. golden cross-validation against QuantStats ----------------------
+
+
+def test_quantstats_metrics_matches_engine_sharpe_and_max_drawdown():
+    qs = pytest.importorskip("quantstats")
+    pd = pytest.importorskip("pandas")
+
+    bt_result = _daily_backtest_result(n=60)
+    engine_metrics = bt_result.metrics()
+
+    returns = qsi.to_quantstats(bt_result, freq="1d")
+    assert isinstance(returns, pd.Series)
+
+    # Must run without raising.
+    report = qsi.quantstats_metrics(bt_result, freq="1d")
+    assert report is not None
+
+    qs_sharpe = qs.stats.sharpe(returns, rf=0.0, periods=252)
+    qs_max_dd = abs(qs.stats.max_drawdown(returns))
+
+    assert qs_sharpe == pytest.approx(engine_metrics["sharpe_ratio"], abs=1e-6)
+    assert qs_max_dd == pytest.approx(engine_metrics["max_drawdown_pct"], abs=1e-6)
+
+
+def test_to_quantstats_missing_pandas_raises_clear_import_error(monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _blocked_import(name, *args, **kwargs):
+        if name == "pandas":
+            raise ImportError("simulated missing pandas")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _blocked_import)
+
+    ts = [1_700_000_000 + i * 86400 for i in range(3)]
+    equity = [100_000.0, 100_500.0, 100_200.0]
+    equity_df = _known_equity_df(ts, equity)
+
+    with pytest.raises(ImportError, match="pip install pandas"):
+        qsi.to_quantstats(equity_df)
+
+
+def test_quantstats_metrics_missing_quantstats_raises_clear_import_error(monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _blocked_import(name, *args, **kwargs):
+        if name == "quantstats":
+            raise ImportError("simulated missing quantstats")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _blocked_import)
+
+    ts = [1_700_000_000 + i * 86400 for i in range(3)]
+    equity = [100_000.0, 100_500.0, 100_200.0]
+    equity_df = _known_equity_df(ts, equity)
+
+    with pytest.raises(ImportError, match="pip install quantstats"):
+        qsi.quantstats_metrics(equity_df)
+
+
+# --- 3. frequency / tz edges ---------------------------------------------
+
+
+def test_backtest_returns_is_tz_aware_ist():
+    ts = [1_700_000_000 + i * 86400 for i in range(3)]
+    equity = [100_000.0, 100_100.0, 100_300.0]
+    equity_df = _known_equity_df(ts, equity)
+
+    result = qsi.backtest_returns(equity_df, freq="1d")
+
+    result_ts = result["ts"].to_list()
+    assert all(t.tzinfo is not None for t in result_ts)
+    # IST is UTC+5:30, and "1d" resampling truncates to the IST calendar-day
+    # boundary, so the returned timestamps land at IST midnight.
+    assert result_ts[0].utcoffset().total_seconds() == 5.5 * 3600
+    assert (result_ts[0].hour, result_ts[0].minute) == (0, 0)
+
+
+def test_daily_resample_keeps_last_equity_per_day():
+    # Two intraday bars per calendar day (12h apart); "1d" resample should
+    # collapse each day down to its last observed equity before diffing.
+    ts = [
+        1_700_000_000,
+        1_700_000_000 + 12 * 3600,
+        1_700_000_000 + 24 * 3600,
+        1_700_000_000 + 36 * 3600,
+    ]
+    equity = [100_000.0, 100_050.0, 100_200.0, 100_100.0]
+    equity_df = _known_equity_df(ts, equity)
+
+    daily = qsi.backtest_returns(equity_df, freq="1d")
+    # Day 1 last equity = 100_050.0, Day 2 last equity = 100_100.0
+    assert daily["return"].to_list() == pytest.approx(
+        [100_100.0 / 100_050.0 - 1.0]
+    )
+
+
+def test_intraday_raw_freq_keeps_every_bar():
+    ts = [
+        1_700_000_000,
+        1_700_000_000 + 12 * 3600,
+        1_700_000_000 + 24 * 3600,
+        1_700_000_000 + 36 * 3600,
+    ]
+    equity = [100_000.0, 100_050.0, 100_200.0, 100_100.0]
+    equity_df = _known_equity_df(ts, equity)
+
+    raw = qsi.backtest_returns(equity_df, freq="raw")
+    assert raw.height == 3
+    expected = [
+        100_050.0 / 100_000.0 - 1.0,
+        100_200.0 / 100_050.0 - 1.0,
+        100_100.0 / 100_200.0 - 1.0,
+    ]
+    assert raw["return"].to_list() == pytest.approx(expected)
+
+
+def test_hourly_resample_freq():
+    # Two bars in the same hour, one bar in the next hour.
+    ts = [1_700_000_000, 1_700_000_000 + 600, 1_700_000_000 + 3600]
+    equity = [100_000.0, 100_010.0, 100_020.0]
+    equity_df = _known_equity_df(ts, equity)
+
+    hourly = qsi.backtest_returns(equity_df, freq="1h")
+    assert hourly.height == 1
+    assert hourly["return"].to_list() == pytest.approx([100_020.0 / 100_010.0 - 1.0])


### PR DESCRIPTION
Two independent p2k0 features built in parallel. Closes **p2k0.5** and **p2k0.7**.

## p2k0.5 — `quantwave.portfolio` (Python-first, numpy)
Covariance estimators (`sample_cov`, `ewma_cov`, `ledoit_wolf_cov`) and optimizers (`min_variance`, `max_sharpe`, `risk_parity` via Spinu fixed-point, `hrp` via hand-rolled single-linkage clustering — scipy is absent). Long-only + per-asset bounds + budget=1 via an exact capped-simplex projection. Degenerate inputs (singular cov, single asset, NaN) raise a typed `PortfolioError` — no crashes, no silent NaN weights.

**Independently verified**: all optimizers sum to 1.0 and respect long-only; min-var variance ≤ equal-weight variance; risk-parity contribution spread = 7.8e-16 (equal to machine precision).

Scope note: this is a deliberate **Python-first v1**; the Rust/nalgebra home in the bead is a documented follow-up (portfolio math has no `Next<T>` parity requirement, so Python-first is legitimate).

## p2k0.7 — QuantStats interop
`qw.backtest_returns(result_or_equity, freq)` -> native Polars returns (tz-aware IST, documented resampling) and `qw.to_quantstats(...)` -> pandas Series behind a lazy import. `BacktestResult` is a native PyO3 class, so these are free functions, not methods. `METRIC_MAPPING` documents the engine-vs-QuantStats Sharpe/MaxDD definitions and the 1e-6 tolerance when frequencies match.

**Independently verified**: `backtest_returns` produces correct pct-change (first row dropped, matches to 1e-12), tz-aware Asia/Kolkata timestamps, all finite. The quantstats cross-validation test `importorskip`s (quantstats/pandas absent here).

## Integration fix (recurring no-deps bug — caught again)
`quantstats_interop` imports polars at module top level; wired unconditionally it would break `import quantwave` on the core (no-polars/numpy) install. Guarded both submodules like the existing `polars`/`bt_polars` pattern. **The pre-push/CI wheel smoke test on a bare venv caught it** — third occurrence of this class from parallel builders, now a known integration checkpoint.

## Verification
- Python suite: **329 passed, 3 skipped** (296 → 329; skips are sklearn/quantstats/pandas `importorskip`)
- Full sanity gate green; wheel smoke passes on a bare no-deps venv

## Not in this batch
`p2k0.9` (alt bar types + harmonics) is Rust-mandated (streaming/batch parity proptest = the moat, `ruh0.1`), so it's held for a focused Rust build rather than a cold parallel worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)