### PR TITLE
feat(bars): constant-range bars (p2k0.9 slice 2)

### DIFF
--- a/docs/generated/validation_stats.json
+++ b/docs/generated/validation_stats.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-18T15:11:03Z",
+  "generated_at": "2026-07-18T16:49:07Z",
   "indicator_count": 221,
   "metadata_with_gold_file": 217,
   "gold_fixture_count": 28,
@@ -36,12 +36,12 @@
   "python_gold_parity_count": 26,
   "python_gold_parity_deferred": 2,
   "rust_tests_by_package": {
-    "quantwave-core": 551,
+    "quantwave-core": 556,
     "quantwave-polars": 45,
     "quantwave-backtest": 92
   },
-  "rust_test_total": 688,
-  "proptest_blocks": 156,
+  "rust_test_total": 693,
+  "proptest_blocks": 157,
   "batch_streaming_parity_checks": 4,
   "talib_parity_test_fns": 134,
   "parity_proptest_indicators": 214,

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -7,7 +7,7 @@ QuantWave's primary credibility claim is **correctness**: one mathematical imple
 ## Coverage snapshot
 
 <!-- VALIDATION:STATS:START -->
-**Last updated:** 2026-07-18T15:11:03Z (UTC)
+**Last updated:** 2026-07-18T16:49:07Z (UTC)
 
 | Metric | Count | Source |
 |--------|------:|--------|
@@ -16,11 +16,11 @@ QuantWave's primary credibility claim is **correctness**: one mathematical imple
 | Gold-standard JSON fixtures (on disk) | **28** | `quantwave-core/tests/gold_standard/` |
 | Python streaming gold parity cases | **26** | `tests/python/gold_parity_registry.py` |
 | Python gold parity deferred (HMM) | 2 | regime fixtures — separate suite |
-| Rust `#[test]` functions (core) | 551 | `rg '#[test]' quantwave-core` |
+| Rust `#[test]` functions (core) | 556 | `rg '#[test]' quantwave-core` |
 | Rust `#[test]` functions (polars) | 45 | `rg '#[test]' quantwave-polars` |
 | Rust `#[test]` functions (backtest) | 92 | `rg '#[test]' quantwave-backtest` |
-| Rust tests (total, 3 crates) | **688** | sum of above |
-| `proptest!` blocks (core) | **156** | `rg 'proptest!\{' quantwave-core` |
+| Rust tests (total, 3 crates) | **693** | sum of above |
+| `proptest!` blocks (core) | **157** | `rg 'proptest!\{' quantwave-core` |
 | `check_batch_streaming_parity` call sites | 4 | indicator modules |
 | TA-Lib parity test functions | 134 | `test_*_talib_parity.rs` |
 | Indicators with proptest parity (CI-enforced) | **214** | `check_indicator_parity_coverage.py` |

--- a/quantwave-core/src/indicators/mod.rs
+++ b/quantwave-core/src/indicators/mod.rs
@@ -90,6 +90,7 @@ pub mod pivot_points;
 pub mod pma;
 pub mod precision_trend;
 pub mod price_transform;
+pub mod range_bars;
 pub mod recursive_median;
 pub mod reflex;
 pub mod renko;

--- a/quantwave-core/src/indicators/range_bars.rs
+++ b/quantwave-core/src/indicators/range_bars.rs
@@ -1,0 +1,158 @@
+//! Range bar construction (price → constant-range OHLC bars).
+//!
+//! A range bar closes as soon as its high-low span reaches `range_size`, then a
+//! new bar opens at the price that triggered the close. Like Renko this discards
+//! time; unlike Renko it keeps full OHLC per bar.
+//!
+//! Two surfaces kept in parity (see the proptest):
+//! - streaming: [`RangeBarBuilder::next`] pushes one price, returns a bar when
+//!   the current bar's span completes (else `None`);
+//! - batch: [`range_bars_batch`] folds the builder over a price slice.
+
+/// One completed range bar. Its `high - low` is `>= range_size`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RangeBar {
+    pub open: f64,
+    pub high: f64,
+    pub low: f64,
+    pub close: f64,
+}
+
+/// Stateful constant-range bar builder.
+#[derive(Debug, Clone)]
+pub struct RangeBarBuilder {
+    range_size: f64,
+    open: f64,
+    high: f64,
+    low: f64,
+    initialized: bool,
+}
+
+impl RangeBarBuilder {
+    /// Create a builder. `range_size` must be strictly positive.
+    pub fn new(range_size: f64) -> Self {
+        Self {
+            range_size,
+            open: 0.0,
+            high: 0.0,
+            low: 0.0,
+            initialized: false,
+        }
+    }
+
+    /// Push one price; return a completed bar if this price closed the current
+    /// bar's span, else `None`.
+    pub fn next(&mut self, price: f64) -> Option<RangeBar> {
+        if self.range_size <= 0.0 || !price.is_finite() {
+            return None;
+        }
+        if !self.initialized {
+            self.open = price;
+            self.high = price;
+            self.low = price;
+            self.initialized = true;
+            return None;
+        }
+        if price > self.high {
+            self.high = price;
+        }
+        if price < self.low {
+            self.low = price;
+        }
+        if self.high - self.low >= self.range_size {
+            let bar = RangeBar {
+                open: self.open,
+                high: self.high,
+                low: self.low,
+                close: price,
+            };
+            // New bar opens at the triggering price.
+            self.open = price;
+            self.high = price;
+            self.low = price;
+            return Some(bar);
+        }
+        None
+    }
+}
+
+/// Batch range bars: fold [`RangeBarBuilder`] over a price slice.
+pub fn range_bars_batch(prices: &[f64], range_size: f64) -> Vec<RangeBar> {
+    let mut b = RangeBarBuilder::new(range_size);
+    let mut out = Vec::new();
+    for &p in prices {
+        if let Some(bar) = b.next(p) {
+            out.push(bar);
+        }
+    }
+    out
+}
+
+/// ATR-range bars: range size is `multiplier * atr` (a single representative ATR).
+pub fn range_bars_atr_batch(prices: &[f64], atr: f64, multiplier: f64) -> Vec<RangeBar> {
+    range_bars_batch(prices, atr * multiplier)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[test]
+    fn gold_single_bar() {
+        // Open 10, climbs to 12 (span 2 >= range 2) → one bar closing at 12.
+        let bars = range_bars_batch(&[10.0, 10.5, 11.0, 12.0], 2.0);
+        assert_eq!(bars.len(), 1);
+        assert_eq!(bars[0].open, 10.0);
+        assert_eq!(bars[0].close, 12.0);
+        assert_eq!(bars[0].high, 12.0);
+        assert_eq!(bars[0].low, 10.0);
+    }
+
+    #[test]
+    fn gold_span_includes_both_directions() {
+        // 10 up to 11, down to 9 → span 11-9=2 completes at 9.
+        let bars = range_bars_batch(&[10.0, 11.0, 9.0], 2.0);
+        assert_eq!(bars.len(), 1);
+        assert_eq!(bars[0].high, 11.0);
+        assert_eq!(bars[0].low, 9.0);
+        assert_eq!(bars[0].close, 9.0);
+    }
+
+    #[test]
+    fn no_bar_within_range() {
+        assert!(range_bars_batch(&[10.0, 10.9, 10.1, 10.5], 2.0).is_empty());
+    }
+
+    proptest! {
+        // Streaming (one at a time) must equal batch (fold).
+        #[test]
+        fn streaming_equals_batch(
+            prices in prop::collection::vec(0.0f64..1000.0, 1..200),
+            range_size in 0.5f64..50.0,
+        ) {
+            let batch = range_bars_batch(&prices, range_size);
+            let mut b = RangeBarBuilder::new(range_size);
+            let mut streamed = Vec::new();
+            for &p in &prices {
+                if let Some(bar) = b.next(p) {
+                    streamed.push(bar);
+                }
+            }
+            prop_assert_eq!(streamed, batch);
+        }
+
+        // Every completed bar's span is at least range_size, with consistent OHLC.
+        #[test]
+        fn bar_span_at_least_range(
+            prices in prop::collection::vec(0.0f64..1000.0, 1..200),
+            range_size in 0.5f64..50.0,
+        ) {
+            for bar in range_bars_batch(&prices, range_size) {
+                prop_assert!(bar.high - bar.low >= range_size - 1e-9);
+                prop_assert!(bar.high >= bar.open && bar.high >= bar.close);
+                prop_assert!(bar.low <= bar.open && bar.low <= bar.close);
+            }
+        }
+    }
+}

--- a/quantwave-core/src/lib.rs
+++ b/quantwave-core/src/lib.rs
@@ -67,6 +67,9 @@ pub use indicators::pa_confluence::{
 pub use indicators::pattern::*;
 pub use indicators::pivot_points::PivotPoints;
 pub use indicators::price_transform::*;
+pub use indicators::range_bars::{
+    RangeBar, RangeBarBuilder, range_bars_atr_batch, range_bars_batch,
+};
 pub use indicators::renko::{RenkoBrick, RenkoBuilder, renko_atr_batch, renko_batch};
 pub use indicators::reverse_ema::ReverseEMA;
 pub use indicators::rodc::RODC;

--- a/quantwave-py/python/quantwave/bars.py
+++ b/quantwave-py/python/quantwave/bars.py
@@ -65,6 +65,35 @@ def renko(
     return _bars.renko(prices, float(box_size))
 
 
+def range_bars(
+    data: "Union[pl.DataFrame, pl.LazyFrame, list[float]]",
+    range_size: "Union[float, str]" = 2.0,
+    *,
+    price_col: str = "close",
+    atr_period: int = 14,
+    multiplier: float = 1.0,
+) -> "pl.DataFrame":
+    """Build constant-range OHLC bars from a price series.
+
+    A bar closes as soon as its high-low span reaches ``range_size`` (a positive
+    float, or ``"atr"`` to derive it from ``multiplier * ATR(atr_period)``); a new
+    bar opens at the triggering price.
+
+    Returns:
+        DataFrame with columns ``open``, ``high``, ``low``, ``close`` (one row per
+        completed bar).
+    """
+    from quantwave import _bars
+
+    prices = _prices(data, price_col)
+    if isinstance(range_size, str):
+        if range_size != "atr":
+            raise ValueError("range_size must be a positive float or 'atr'")
+        atr = _atr_value(data, price_col, atr_period)
+        return _bars.range_bars_atr(prices, atr, multiplier)
+    return _bars.range_bars(prices, float(range_size))
+
+
 def _atr_value(data, price_col: str, period: int) -> float:
     """A single representative ATR over the series (mean true range)."""
     pl = _pl()

--- a/quantwave-py/src/bars.rs
+++ b/quantwave-py/src/bars.rs
@@ -8,7 +8,9 @@ use polars::prelude::*;
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3_polars::PyDataFrame;
-use quantwave_core::{RenkoBrick, renko_atr_batch, renko_batch};
+use quantwave_core::{
+    RangeBar, RenkoBrick, range_bars_atr_batch, range_bars_batch, renko_atr_batch, renko_batch,
+};
 
 fn bricks_to_frame(bricks: &[RenkoBrick]) -> PolarsResult<DataFrame> {
     let open: Vec<f64> = bricks.iter().map(|b| b.open).collect();
@@ -18,6 +20,15 @@ fn bricks_to_frame(bricks: &[RenkoBrick]) -> PolarsResult<DataFrame> {
         "open" => open,
         "close" => close,
         "direction" => direction,
+    ]
+}
+
+fn range_bars_to_frame(bars: &[RangeBar]) -> PolarsResult<DataFrame> {
+    df![
+        "open" => bars.iter().map(|b| b.open).collect::<Vec<f64>>(),
+        "high" => bars.iter().map(|b| b.high).collect::<Vec<f64>>(),
+        "low" => bars.iter().map(|b| b.low).collect::<Vec<f64>>(),
+        "close" => bars.iter().map(|b| b.close).collect::<Vec<f64>>(),
     ]
 }
 
@@ -46,8 +57,34 @@ fn renko_atr(prices: Vec<f64>, atr: f64, multiplier: f64) -> PyResult<PyDataFram
     Ok(PyDataFrame(df))
 }
 
+/// Constant-range bars: `prices` → DataFrame with columns open/high/low/close.
+#[pyfunction]
+#[pyo3(signature = (prices, range_size))]
+fn range_bars(prices: Vec<f64>, range_size: f64) -> PyResult<PyDataFrame> {
+    if !(range_size > 0.0) {
+        return Err(PyValueError::new_err("range_size must be > 0"));
+    }
+    let df = range_bars_to_frame(&range_bars_batch(&prices, range_size))
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+    Ok(PyDataFrame(df))
+}
+
+/// ATR-range bars: range size = `multiplier * atr`.
+#[pyfunction]
+#[pyo3(signature = (prices, atr, multiplier=1.0))]
+fn range_bars_atr(prices: Vec<f64>, atr: f64, multiplier: f64) -> PyResult<PyDataFrame> {
+    if !(atr > 0.0) || !(multiplier > 0.0) {
+        return Err(PyValueError::new_err("atr and multiplier must be > 0"));
+    }
+    let df = range_bars_to_frame(&range_bars_atr_batch(&prices, atr, multiplier))
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+    Ok(PyDataFrame(df))
+}
+
 pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(renko, m)?)?;
     m.add_function(wrap_pyfunction!(renko_atr, m)?)?;
+    m.add_function(wrap_pyfunction!(range_bars, m)?)?;
+    m.add_function(wrap_pyfunction!(range_bars_atr, m)?)?;
     Ok(())
 }

--- a/tests/python/test_bars.py
+++ b/tests/python/test_bars.py
@@ -52,3 +52,36 @@ def test_renko_invalid_box_raises():
         qw.bars.renko([10.0, 11.0], box_size=0.0)
     with pytest.raises(ValueError):
         qw.bars.renko([10.0, 11.0], box_size="bogus")
+
+
+def test_range_bars_single_bar():
+    b = qw.bars.range_bars([10.0, 10.5, 11.0, 12.0], range_size=2.0)
+    assert b.columns == ["open", "high", "low", "close"]
+    assert b.height == 1
+    assert b.row(0) == (10.0, 12.0, 10.0, 12.0)
+
+
+def test_range_bars_span_both_directions():
+    b = qw.bars.range_bars([10.0, 11.0, 9.0], range_size=2.0)
+    assert b.height == 1
+    assert b["high"][0] == 11.0 and b["low"][0] == 9.0 and b["close"][0] == 9.0
+
+
+def test_range_bars_no_bar_within_range():
+    assert qw.bars.range_bars([10.0, 10.9, 10.1, 10.5], range_size=2.0).height == 0
+
+
+def test_range_bars_span_invariant():
+    df = qw.datasets.synthetic(seed=4, rows=300)
+    b = qw.bars.range_bars(df, range_size=3.0)
+    spans = b["high"] - b["low"]
+    assert (spans >= 3.0 - 1e-9).all()
+
+
+def test_range_bars_atr_and_errors():
+    df = qw.datasets.synthetic(seed=6, rows=200)
+    assert qw.bars.range_bars(df, range_size="atr", multiplier=2.0).height > 0
+    with pytest.raises(Exception):
+        qw.bars.range_bars([10.0, 11.0], range_size=0.0)
+    with pytest.raises(ValueError):
+        qw.bars.range_bars([10.0, 11.0], range_size="bogus")


### PR DESCRIPTION
Second slice of **p2k0.9**, following the Renko pattern (PR #23). Constant-range OHLC bars.

## Rust core (`quantwave-core/src/indicators/range_bars.rs`)
- `RangeBarBuilder` (Next-style `push` → `Option<RangeBar>`) + `range_bars_batch` + `range_bars_atr_batch`.
- A bar closes when its high-low span reaches `range_size`; a new bar opens at the triggering price. Full OHLC per bar.
- **5 tests**: 3 gold fixtures (single bar / both-direction span / no-bar-within-range) + 2 proptests — **streaming == batch parity** and the span ≥ range_size invariant.

## Python
- `qw.bars.range_bars(df_or_prices, range_size=float | "atr", price_col=, atr_period=, multiplier=)` → `DataFrame[open, high, low, close]` via the `_bars` submodule; late-bind polars.

## Verification
- `quantwave-core`: 5 range_bars tests pass (incl. parity proptest)
- Python: `test_bars` **12 passed** (7 renko + 5 range); full suite **342 passed, 3 skipped**
- No-deps wheel smoke passes; validation stats regenerated (+5 tests / +2 proptests); bead-ID clean

## Remaining p2k0.9 slices
Kagi, P&F, harmonic patterns (Gartley/Bat/Butterfly), docs section. `p2k0.9` stays in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)