### PR TITLE
fix(bars): correct Renko to Drozda et al. (2024) Definition 1

### DIFF
--- a/docs/generated/validation_stats.json
+++ b/docs/generated/validation_stats.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-18T16:49:07Z",
+  "generated_at": "2026-07-18T17:51:34Z",
   "indicator_count": 221,
   "metadata_with_gold_file": 217,
   "gold_fixture_count": 28,
@@ -36,11 +36,11 @@
   "python_gold_parity_count": 26,
   "python_gold_parity_deferred": 2,
   "rust_tests_by_package": {
-    "quantwave-core": 556,
+    "quantwave-core": 557,
     "quantwave-polars": 45,
     "quantwave-backtest": 92
   },
-  "rust_test_total": 693,
+  "rust_test_total": 694,
   "proptest_blocks": 157,
   "batch_streaming_parity_checks": 4,
   "talib_parity_test_fns": 134,

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -7,7 +7,7 @@ QuantWave's primary credibility claim is **correctness**: one mathematical imple
 ## Coverage snapshot
 
 <!-- VALIDATION:STATS:START -->
-**Last updated:** 2026-07-18T16:49:07Z (UTC)
+**Last updated:** 2026-07-18T17:51:34Z (UTC)
 
 | Metric | Count | Source |
 |--------|------:|--------|
@@ -16,10 +16,10 @@ QuantWave's primary credibility claim is **correctness**: one mathematical imple
 | Gold-standard JSON fixtures (on disk) | **28** | `quantwave-core/tests/gold_standard/` |
 | Python streaming gold parity cases | **26** | `tests/python/gold_parity_registry.py` |
 | Python gold parity deferred (HMM) | 2 | regime fixtures — separate suite |
-| Rust `#[test]` functions (core) | 556 | `rg '#[test]' quantwave-core` |
+| Rust `#[test]` functions (core) | 557 | `rg '#[test]' quantwave-core` |
 | Rust `#[test]` functions (polars) | 45 | `rg '#[test]' quantwave-polars` |
 | Rust `#[test]` functions (backtest) | 92 | `rg '#[test]' quantwave-backtest` |
-| Rust tests (total, 3 crates) | **693** | sum of above |
+| Rust tests (total, 3 crates) | **694** | sum of above |
 | `proptest!` blocks (core) | **157** | `rg 'proptest!\{' quantwave-core` |
 | `check_batch_streaming_parity` call sites | 4 | indicator modules |
 | TA-Lib parity test functions | 134 | `test_*_talib_parity.rs` |

--- a/quantwave-core/src/indicators/renko.rs
+++ b/quantwave-core/src/indicators/renko.rs
@@ -1,17 +1,27 @@
-//! Renko bar construction (price → fixed/ATR-box bricks).
+//! Renko bar construction (close-based, Drozda et al. 2024 Definition 1).
 //!
-//! Renko discards time and volume: a new brick is emitted only when price moves
-//! a full `box_size` from the last brick boundary. This implementation is
-//! close-based with a 1-box reversal (a direction change needs one full box past
-//! the last brick close), and emits multiple bricks when price jumps several
-//! boxes in one step.
+//! A Renko brick spans a fixed height `ΔP` (the "box"); a new brick is created
+//! only when the latest *close* leaves the current brick's `[min, max]` band, so
+//! small moves are filtered out. This follows the formal definition in:
 //!
-//! Two surfaces, kept in parity (see the proptest below):
-//! - streaming: [`RenkoBuilder::next`] pushes one price, returns 0+ new bricks;
-//! - batch: [`renko_batch`] folds the builder over a price slice.
+//!   Drozda, Cavojsky, Sebes (2024), "On Suitability of Renko Charts for
+//!   Algorithmic Trading". Def. 1: the first brick `R⁰` is anchored at the first
+//!   close `p₀`; a close above `p_max` creates an up-brick `[p_max, p_max + ΔP]`
+//!   and a close below `p_min` creates a down-brick `[p_min − ΔP, p_min]`
+//!   (adjacent, non-retracing); several bricks may be created for one close.
+//!   `ΔP` may vary per brick, so an ATR-derived box is the natural default.
+//!
+//! A high/low-based variant (symmetric threshold `|P(u) − P(τ)| = H`) is used for
+//! pairs trading in Bogomolov (2013), "Pairs trading based on statistical
+//! variability of the spread process", Quantitative Finance 13(9): 1411–1430;
+//! this module implements the close-based Drozda definition.
+//!
+//! Two surfaces kept in parity (see the proptest):
+//! - streaming: [`RenkoBuilder::next`] pushes one close, returns 0+ new bricks;
+//! - batch: [`renko_batch`] folds the builder over a close slice.
 
 /// One Renko brick. `direction` is +1 (up) or -1 (down); `open`/`close` are the
-/// brick's price boundaries `box_size` apart.
+/// brick's price boundaries `box_size` apart, in the direction of travel.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RenkoBrick {
     pub open: f64,
@@ -19,82 +29,113 @@ pub struct RenkoBrick {
     pub direction: i8,
 }
 
-/// Stateful close-based Renko builder with a fixed box size.
+/// Stateful close-based Renko builder (Drozda et al. 2024, Def. 1) with a fixed
+/// box size.
 #[derive(Debug, Clone)]
 pub struct RenkoBuilder {
     box_size: f64,
-    /// Boundary the next brick is measured from (close of the last brick).
+    /// First close, used to anchor the first brick (Def. 1: `R⁰` at `p₀`).
     anchor: f64,
-    direction: i8,
-    initialized: bool,
+    anchored: bool,
+    /// Current brick band `[min, max]`; valid once `started`.
+    min: f64,
+    max: f64,
+    started: bool,
 }
 
 impl RenkoBuilder {
-    /// Create a builder. `box_size` must be strictly positive.
+    /// Create a builder. `box_size` (`ΔP`) must be strictly positive.
     pub fn new(box_size: f64) -> Self {
         Self {
             box_size,
             anchor: 0.0,
-            direction: 0,
-            initialized: false,
+            anchored: false,
+            min: 0.0,
+            max: 0.0,
+            started: false,
         }
     }
 
-    /// Push one price; return any bricks that completed at this price (0+).
-    pub fn next(&mut self, price: f64) -> Vec<RenkoBrick> {
+    /// Push one close; return any bricks created by it (0+).
+    pub fn next(&mut self, close: f64) -> Vec<RenkoBrick> {
         let mut out = Vec::new();
-        if self.box_size <= 0.0 || !price.is_finite() {
+        if self.box_size <= 0.0 || !close.is_finite() {
             return out;
         }
-        if !self.initialized {
-            // Anchor the grid to the first price (floor to a box multiple so
-            // brick boundaries are stable regardless of the starting value).
-            self.anchor = (price / self.box_size).floor() * self.box_size;
-            self.initialized = true;
+        if !self.anchored {
+            self.anchor = close;
+            self.anchored = true;
             return out;
         }
-        while price >= self.anchor + self.box_size {
-            let open = self.anchor;
-            let close = self.anchor + self.box_size;
+        if !self.started {
+            // First brick forms after a full box move from p₀, either direction.
+            if close >= self.anchor + self.box_size {
+                let mut bottom = self.anchor;
+                while close >= bottom + self.box_size {
+                    out.push(RenkoBrick {
+                        open: bottom,
+                        close: bottom + self.box_size,
+                        direction: 1,
+                    });
+                    bottom += self.box_size;
+                }
+                self.min = bottom - self.box_size;
+                self.max = bottom;
+                self.started = true;
+            } else if close <= self.anchor - self.box_size {
+                let mut top = self.anchor;
+                while close <= top - self.box_size {
+                    out.push(RenkoBrick {
+                        open: top,
+                        close: top - self.box_size,
+                        direction: -1,
+                    });
+                    top -= self.box_size;
+                }
+                self.max = top + self.box_size;
+                self.min = top;
+                self.started = true;
+            }
+            return out;
+        }
+        // Continuation / reversal via Def. 1 formulas on the current band.
+        while close > self.max {
             out.push(RenkoBrick {
-                open,
-                close,
+                open: self.max,
+                close: self.max + self.box_size,
                 direction: 1,
             });
-            self.anchor = close;
-            self.direction = 1;
+            self.min = self.max;
+            self.max += self.box_size;
         }
-        while price <= self.anchor - self.box_size {
-            let open = self.anchor;
-            let close = self.anchor - self.box_size;
+        while close < self.min {
             out.push(RenkoBrick {
-                open,
-                close,
+                open: self.min,
+                close: self.min - self.box_size,
                 direction: -1,
             });
-            self.anchor = close;
-            self.direction = -1;
+            self.max = self.min;
+            self.min -= self.box_size;
         }
         out
     }
 }
 
-/// Batch Renko: fold [`RenkoBuilder`] over a price slice, returning all bricks.
-pub fn renko_batch(prices: &[f64], box_size: f64) -> Vec<RenkoBrick> {
+/// Batch Renko: fold [`RenkoBuilder`] over a close slice, returning all bricks.
+pub fn renko_batch(closes: &[f64], box_size: f64) -> Vec<RenkoBrick> {
     let mut b = RenkoBuilder::new(box_size);
     let mut out = Vec::new();
-    for &p in prices {
-        out.extend(b.next(p));
+    for &c in closes {
+        out.extend(b.next(c));
     }
     out
 }
 
-/// ATR-box Renko: box size is `multiplier * atr`, where `atr` is a single
-/// representative volatility value (e.g. the ATR over the whole series). Callers
-/// that want a per-bar adaptive box should segment and re-run; a fixed box per
-/// run keeps brick boundaries well-defined and reproducible.
-pub fn renko_atr_batch(prices: &[f64], atr: f64, multiplier: f64) -> Vec<RenkoBrick> {
-    renko_batch(prices, atr * multiplier)
+/// ATR-box Renko: box size is `multiplier * atr`, a single representative
+/// volatility value (Drozda et al. use ATR as the default box). Per Def. 1 the
+/// box may vary per brick; a fixed box per run keeps boundaries reproducible.
+pub fn renko_atr_batch(closes: &[f64], atr: f64, multiplier: f64) -> Vec<RenkoBrick> {
+    renko_batch(closes, atr * multiplier)
 }
 
 #[cfg(test)]
@@ -103,8 +144,8 @@ mod tests {
     use proptest::prelude::*;
 
     #[test]
-    fn gold_simple_uptrend() {
-        // box=1, anchored at floor(10)=10. Prices climbing to 13 → 3 up bricks.
+    fn gold_uptrend() {
+        // box=1, anchor p₀=10. Climb to 13 → up bricks [10,11],[11,12],[12,13].
         let bricks = renko_batch(&[10.0, 10.5, 11.0, 12.4, 13.0], 1.0);
         assert_eq!(bricks.len(), 3);
         for (i, b) in bricks.iter().enumerate() {
@@ -115,58 +156,72 @@ mod tests {
     }
 
     #[test]
-    fn gold_reversal() {
-        // Up to 12 (2 bricks), then down to 9 → down bricks from anchor 12.
+    fn gold_reversal_is_non_retracing() {
+        // Up to 12 → bricks [10,11],[11,12] (band min=11). Reversal: close 10 < 11
+        // → down brick [10,11]; close 9 < 10 → down brick [9,10]. Def. 1 places
+        // reversal bricks adjacent below the band — it does NOT retrace [11,12].
         let bricks = renko_batch(&[10.0, 12.0, 11.5, 10.0, 9.0], 1.0);
         let dirs: Vec<i8> = bricks.iter().map(|b| b.direction).collect();
-        assert_eq!(dirs, vec![1, 1, -1, -1, -1]);
+        assert_eq!(dirs, vec![1, 1, -1, -1]);
+        assert_eq!(bricks[2].open, 11.0);
+        assert_eq!(bricks[2].close, 10.0);
         assert_eq!(bricks.last().unwrap().close, 9.0);
     }
 
     #[test]
     fn no_brick_within_box() {
-        // Movement smaller than the box → no bricks.
         assert!(renko_batch(&[10.0, 10.9, 10.1, 10.99], 1.0).is_empty());
     }
 
+    #[test]
+    fn multi_brick_on_gap() {
+        // A single close far above p₀ creates several bricks at once.
+        let bricks = renko_batch(&[10.0, 13.0], 1.0);
+        assert_eq!(bricks.len(), 3);
+        assert!(bricks.iter().all(|b| b.direction == 1));
+    }
+
     proptest! {
-        // Streaming (push one at a time) must equal batch (fold over the slice).
+        // Streaming (one at a time) must equal batch (fold).
         #[test]
         fn streaming_equals_batch(
-            prices in prop::collection::vec(0.0f64..1000.0, 1..200),
+            closes in prop::collection::vec(0.0f64..1000.0, 1..200),
             box_size in 0.5f64..50.0,
         ) {
-            let batch = renko_batch(&prices, box_size);
+            let batch = renko_batch(&closes, box_size);
             let mut b = RenkoBuilder::new(box_size);
             let mut streamed = Vec::new();
-            for &p in &prices {
-                streamed.extend(b.next(p));
+            for &c in &closes {
+                streamed.extend(b.next(c));
             }
             prop_assert_eq!(streamed, batch);
         }
 
-        // Every brick spans exactly one box, in its stated direction.
+        // Every brick spans exactly one box in its stated direction.
         #[test]
         fn brick_spans_one_box(
-            prices in prop::collection::vec(0.0f64..1000.0, 1..200),
+            closes in prop::collection::vec(0.0f64..1000.0, 1..200),
             box_size in 0.5f64..50.0,
         ) {
-            for brick in renko_batch(&prices, box_size) {
+            for brick in renko_batch(&closes, box_size) {
                 let span = brick.close - brick.open;
                 prop_assert!((span.abs() - box_size).abs() < 1e-9);
                 prop_assert_eq!(span.signum() as i8, brick.direction);
             }
         }
 
-        // Consecutive brick boundaries are contiguous (each open == previous close).
+        // Def. 1 anchors to p₀: every boundary lies on the p₀ + k·box grid.
         #[test]
-        fn bricks_are_contiguous(
-            prices in prop::collection::vec(0.0f64..1000.0, 1..200),
+        fn boundaries_on_p0_grid(
+            closes in prop::collection::vec(0.0f64..1000.0, 1..200),
             box_size in 0.5f64..50.0,
         ) {
-            let bricks = renko_batch(&prices, box_size);
-            for pair in bricks.windows(2) {
-                prop_assert!((pair[1].open - pair[0].close).abs() < 1e-9);
+            let p0 = closes[0];
+            for brick in renko_batch(&closes, box_size) {
+                for edge in [brick.open, brick.close] {
+                    let k = (edge - p0) / box_size;
+                    prop_assert!((k - k.round()).abs() < 1e-6);
+                }
             }
         }
     }

--- a/tests/python/test_bars.py
+++ b/tests/python/test_bars.py
@@ -15,9 +15,12 @@ def test_renko_fixed_box_uptrend():
     assert b["close"].to_list() == [11.0, 12.0, 13.0]
 
 
-def test_renko_reversal():
+def test_renko_reversal_non_retracing():
+    # Drozda Def. 1: reversal bricks are adjacent below the band, not retracing
+    # the last up-brick — up to 12 gives [10,11],[11,12]; reversal to 9 gives
+    # [11,10],[10,9] → dirs [1,1,-1,-1].
     b = qw.bars.renko([10.0, 12.0, 11.5, 10.0, 9.0], box_size=1.0)
-    assert b["direction"].to_list() == [1, 1, -1, -1, -1]
+    assert b["direction"].to_list() == [1, 1, -1, -1]
     assert b["close"].to_list()[-1] == 9.0
 
 


### PR DESCRIPTION
The initial Renko slice (PR #23) used an arbitrary grid-floor anchor and a *retracing* reversal — a valid close-based Renko, but not a cited one. Reworked to the formal definition supplied as the authoritative source:

> **Drozda, Cavojsky, Sebes (2024), "On Suitability of Renko Charts for Algorithmic Trading", Definition 1** (close-based, ATR-default box).

## Corrections
- **Anchor `R⁰` to the first close `p₀`** (not `floor(p/box)*box`) — brick boundaries now lie on the `p₀ + k·box` grid. Live: a series starting at `10.3` now opens bricks at `10.3, 11.3, 12.3` (was `10, 11, 12`).
- **Non-retracing reversal**: a close `< min` creates an adjacent down-brick `[min−ΔP, min]` below the band, per Def. 1 — previously a reversal retraced the last brick. Live: the reversal fixture is now `[1,1,-1,-1]` (was `[1,1,-1,-1,-1]`).
- Continuation + multi-brick per Def. 1's formulas; ATR box is the natural per-brick `ΔP` (as the paper uses).
- **Citations recorded** in the module docstring: Drozda (2024, close-based) and Bogomolov (2013, *Quantitative Finance* 13(9) — the high/low-based pairs-trading variant), per the repo's source-recording convention.

## Tests
- 7 Rust tests: 4 gold fixtures (uptrend / **non-retracing reversal** / no-brick / multi-brick-on-gap) + 3 proptests — streaming==batch parity, one-box span, and a new **`p₀`-grid-alignment** property derived from Def. 1.
- Updated the Python reversal test to the non-retracing behavior.

## Verification
- `quantwave-core`: 7 renko tests pass
- Python suite: **342 passed, 3 skipped**; no-deps wheel smoke passes; validation stats regenerated

Closes the Renko-source-correction follow-up. (Range bars remain on the earlier variant; a Kagi slice will use Bogomolov's `Sₙ = sign(...)` construction.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)