### PR TITLE
feat(bars): Kagi line construction (p2k0.9 slice 3)

### DIFF
--- a/docs/generated/validation_stats.json
+++ b/docs/generated/validation_stats.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-18T17:51:34Z",
+  "generated_at": "2026-07-19T02:27:45Z",
   "indicator_count": 221,
   "metadata_with_gold_file": 217,
   "gold_fixture_count": 28,
@@ -36,12 +36,12 @@
   "python_gold_parity_count": 26,
   "python_gold_parity_deferred": 2,
   "rust_tests_by_package": {
-    "quantwave-core": 557,
+    "quantwave-core": 563,
     "quantwave-polars": 45,
     "quantwave-backtest": 92
   },
-  "rust_test_total": 694,
-  "proptest_blocks": 157,
+  "rust_test_total": 700,
+  "proptest_blocks": 158,
   "batch_streaming_parity_checks": 4,
   "talib_parity_test_fns": 134,
   "parity_proptest_indicators": 214,

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -7,7 +7,7 @@ QuantWave's primary credibility claim is **correctness**: one mathematical imple
 ## Coverage snapshot
 
 <!-- VALIDATION:STATS:START -->
-**Last updated:** 2026-07-18T17:51:34Z (UTC)
+**Last updated:** 2026-07-19T02:27:45Z (UTC)
 
 | Metric | Count | Source |
 |--------|------:|--------|
@@ -16,11 +16,11 @@ QuantWave's primary credibility claim is **correctness**: one mathematical imple
 | Gold-standard JSON fixtures (on disk) | **28** | `quantwave-core/tests/gold_standard/` |
 | Python streaming gold parity cases | **26** | `tests/python/gold_parity_registry.py` |
 | Python gold parity deferred (HMM) | 2 | regime fixtures — separate suite |
-| Rust `#[test]` functions (core) | 557 | `rg '#[test]' quantwave-core` |
+| Rust `#[test]` functions (core) | 563 | `rg '#[test]' quantwave-core` |
 | Rust `#[test]` functions (polars) | 45 | `rg '#[test]' quantwave-polars` |
 | Rust `#[test]` functions (backtest) | 92 | `rg '#[test]' quantwave-backtest` |
-| Rust tests (total, 3 crates) | **694** | sum of above |
-| `proptest!` blocks (core) | **157** | `rg 'proptest!\{' quantwave-core` |
+| Rust tests (total, 3 crates) | **700** | sum of above |
+| `proptest!` blocks (core) | **158** | `rg 'proptest!\{' quantwave-core` |
 | `check_batch_streaming_parity` call sites | 4 | indicator modules |
 | TA-Lib parity test functions | 134 | `test_*_talib_parity.rs` |
 | Indicators with proptest parity (CI-enforced) | **214** | `check_indicator_parity_coverage.py` |

--- a/quantwave-core/src/indicators/kagi.rs
+++ b/quantwave-core/src/indicators/kagi.rs
@@ -1,0 +1,264 @@
+//! Kagi line construction (price → alternating up/down lines).
+//!
+//! A Kagi chart discards time and draws a single connected line that keeps
+//! extending in the current direction while price advances, and reverses only
+//! when price retraces from the running extreme by at least the reversal amount
+//! `H`. Each completed *line* runs between two consecutive turning points (true
+//! price extrema — the tops/"shoulders" and bottoms/"waists").
+//!
+//! Reversal construction (threshold `H`, extrema as turning points) follows:
+//!
+//!   Bogomolov (2013), "Pairs trading based on statistical variability of the
+//!   spread process", Quantitative Finance 13(9): 1411–1430 — which formalises
+//!   the Kagi (and Renko) constructions as model-free, time-independent samplers
+//!   of a price path driven by a single threshold `H`: an up-move reverses at the
+//!   first price `<= running_max − H`, a down-move at the first `>= running_min + H`.
+//!
+//! The yin/yang `thickness` follows the classic charting convention (Nison,
+//! "Beyond Candlesticks", 1994): the line turns **yang** (`+1`, thick/bullish)
+//! when price rises above the prior shoulder, and **yin** (`-1`, thin/bearish)
+//! when it falls below the prior waist; it holds its state in between. This is
+//! the machine-readable Kagi signal, kept separate from any visualization.
+//!
+//! Two surfaces kept in parity (see the proptest):
+//! - streaming: [`KagiBuilder::next`] pushes one price, returns a line when the
+//!   current direction reverses (else `None`);
+//! - batch: [`kagi_batch`] folds the builder over a price slice.
+
+/// One completed Kagi line, running between two consecutive turning points.
+/// `direction` is +1 (up) / -1 (down); `thickness` is +1 (yang), -1 (yin), or 0
+/// (undetermined — no prior shoulder/waist has been broken yet).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct KagiLine {
+    /// Start turning point (the previous extreme the line departs from).
+    pub open: f64,
+    /// End turning point (the extreme where the reversal was confirmed).
+    pub close: f64,
+    pub direction: i8,
+    pub thickness: i8,
+}
+
+/// Stateful Kagi builder with a fixed reversal amount `H`.
+#[derive(Debug, Clone)]
+pub struct KagiBuilder {
+    reversal: f64,
+    /// Start price of the current line (previous turning point, or the anchor).
+    start: f64,
+    /// Running extreme of the current line (max while up, min while down).
+    extreme: f64,
+    /// Current trend: +1 up, -1 down, 0 undetermined (before the first `H`-move).
+    direction: i8,
+    /// Most recent top turning point (set when an up-line completes).
+    shoulder: Option<f64>,
+    /// Most recent bottom turning point (set when a down-line completes).
+    waist: Option<f64>,
+    /// Current yin/yang state; carries over until a shoulder/waist break flips it.
+    thickness: i8,
+    initialized: bool,
+}
+
+impl KagiBuilder {
+    /// Create a builder. `reversal` (`H`) must be strictly positive.
+    pub fn new(reversal: f64) -> Self {
+        Self {
+            reversal,
+            start: 0.0,
+            extreme: 0.0,
+            direction: 0,
+            shoulder: None,
+            waist: None,
+            thickness: 0,
+            initialized: false,
+        }
+    }
+
+    /// Update the yin/yang state from a price crossing the prior shoulder/waist.
+    fn update_thickness(&mut self, price: f64) {
+        if let Some(s) = self.shoulder
+            && price > s
+        {
+            self.thickness = 1;
+        }
+        if let Some(w) = self.waist
+            && price < w
+        {
+            self.thickness = -1;
+        }
+    }
+
+    /// Push one price; return a completed line if this price confirmed a reversal
+    /// of the current direction, else `None`.
+    pub fn next(&mut self, price: f64) -> Option<KagiLine> {
+        if self.reversal <= 0.0 || !price.is_finite() {
+            return None;
+        }
+        if !self.initialized {
+            self.start = price;
+            self.extreme = price;
+            self.initialized = true;
+            return None;
+        }
+        if self.direction == 0 {
+            // Undetermined: the first `H`-move from the anchor fixes the trend.
+            if price >= self.start + self.reversal {
+                self.direction = 1;
+                self.extreme = price;
+            } else if price <= self.start - self.reversal {
+                self.direction = -1;
+                self.extreme = price;
+            }
+            self.update_thickness(price);
+            return None;
+        }
+        if self.direction == 1 {
+            if price > self.extreme {
+                // Line still advancing: thickness tracks the price making the high.
+                self.extreme = price;
+                self.update_thickness(price);
+            } else if price <= self.extreme - self.reversal {
+                // Up-line completes at its top (a new shoulder); a down-line opens.
+                // `thickness` is the state at the top, before the triggering price
+                // (which belongs to the new down-line) touches it.
+                let line = KagiLine {
+                    open: self.start,
+                    close: self.extreme,
+                    direction: 1,
+                    thickness: self.thickness,
+                };
+                self.shoulder = Some(self.extreme);
+                self.start = self.extreme;
+                self.direction = -1;
+                self.extreme = price;
+                self.update_thickness(price);
+                return Some(line);
+            }
+        } else {
+            if price < self.extreme {
+                self.extreme = price;
+                self.update_thickness(price);
+            } else if price >= self.extreme + self.reversal {
+                // Down-line completes at its bottom (a new waist); an up-line opens.
+                let line = KagiLine {
+                    open: self.start,
+                    close: self.extreme,
+                    direction: -1,
+                    thickness: self.thickness,
+                };
+                self.waist = Some(self.extreme);
+                self.start = self.extreme;
+                self.direction = 1;
+                self.extreme = price;
+                self.update_thickness(price);
+                return Some(line);
+            }
+        }
+        None
+    }
+}
+
+/// Batch Kagi: fold [`KagiBuilder`] over a price slice, returning completed lines.
+pub fn kagi_batch(prices: &[f64], reversal: f64) -> Vec<KagiLine> {
+    let mut b = KagiBuilder::new(reversal);
+    let mut out = Vec::new();
+    for &p in prices {
+        if let Some(line) = b.next(p) {
+            out.push(line);
+        }
+    }
+    out
+}
+
+/// ATR-reversal Kagi: reversal amount is `multiplier * atr` (a single
+/// representative ATR), matching the ATR box convention of the other bar types.
+pub fn kagi_atr_batch(prices: &[f64], atr: f64, multiplier: f64) -> Vec<KagiLine> {
+    kagi_batch(prices, atr * multiplier)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[test]
+    fn gold_single_reversal() {
+        // Anchor 10, H=2. Rise to 14 (up-line), retrace to 11 (<= 14-2) → the
+        // up-line [10,14] completes; nothing else confirmed yet.
+        let lines = kagi_batch(&[10.0, 12.0, 14.0, 11.0], 2.0);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].open, 10.0);
+        assert_eq!(lines[0].close, 14.0);
+        assert_eq!(lines[0].direction, 1);
+    }
+
+    #[test]
+    fn gold_alternating_directions() {
+        // Up to 14, down to 10 (<=14-2 reverses; new bottom 10), up to 14 again
+        // (>=10+2 reverses). Lines: up [10,14], down [14,10]. Directions alternate.
+        let lines = kagi_batch(&[10.0, 14.0, 10.0, 14.0], 2.0);
+        let dirs: Vec<i8> = lines.iter().map(|l| l.direction).collect();
+        assert_eq!(dirs, vec![1, -1]);
+        assert_eq!(lines[0].open, 10.0);
+        assert_eq!(lines[0].close, 14.0);
+        assert_eq!(lines[1].open, 14.0);
+        assert_eq!(lines[1].close, 10.0);
+    }
+
+    #[test]
+    fn gold_no_reversal_within_threshold() {
+        // Small wiggles never retrace a full H from the extreme → no completed line.
+        assert!(kagi_batch(&[10.0, 11.0, 10.2, 11.5, 10.8], 2.0).is_empty());
+    }
+
+    #[test]
+    fn gold_yang_on_higher_high() {
+        // First up-line [10,14] sets shoulder=14 (thickness 0, no prior shoulder).
+        // Reverse down to 11 → down-line [14,11], waist=11. Rise: crossing 14
+        // (prior shoulder) turns the line yang; peak 17 then retrace to 14 (<=17-2)
+        // completes an up-line with thickness +1 (yang).
+        let lines = kagi_batch(&[10.0, 14.0, 11.0, 17.0, 14.0], 2.0);
+        assert_eq!(lines.len(), 3);
+        assert_eq!(lines[0].thickness, 0); // no prior shoulder to break
+        assert_eq!(lines[1].direction, -1);
+        assert_eq!(lines[2].direction, 1);
+        assert_eq!(lines[2].thickness, 1); // broke above prior shoulder 14 → yang
+    }
+
+    proptest! {
+        // Streaming (one at a time) must equal batch (fold).
+        #[test]
+        fn streaming_equals_batch(
+            prices in prop::collection::vec(0.0f64..1000.0, 1..200),
+            reversal in 0.5f64..50.0,
+        ) {
+            let batch = kagi_batch(&prices, reversal);
+            let mut b = KagiBuilder::new(reversal);
+            let mut streamed = Vec::new();
+            for &p in &prices {
+                if let Some(line) = b.next(p) {
+                    streamed.push(line);
+                }
+            }
+            prop_assert_eq!(streamed, batch);
+        }
+
+        // Consecutive lines strictly alternate direction, each connected end-to-
+        // start, and each spans at least the reversal amount.
+        #[test]
+        fn lines_alternate_and_connect(
+            prices in prop::collection::vec(0.0f64..1000.0, 1..200),
+            reversal in 0.5f64..50.0,
+        ) {
+            let lines = kagi_batch(&prices, reversal);
+            for w in lines.windows(2) {
+                prop_assert_eq!(w[0].direction, -w[1].direction);
+                prop_assert_eq!(w[0].close, w[1].open); // connected turning point
+            }
+            for l in &lines {
+                let span = l.close - l.open;
+                prop_assert!((span.abs()) >= reversal - 1e-9);
+                prop_assert_eq!(span.signum() as i8, l.direction);
+                prop_assert!(l.thickness >= -1 && l.thickness <= 1);
+            }
+        }
+    }
+}

--- a/quantwave-core/src/indicators/mod.rs
+++ b/quantwave-core/src/indicators/mod.rs
@@ -61,6 +61,7 @@ pub mod incremental;
 pub mod instantaneous_trendline;
 pub mod inverse_fisher;
 pub mod just_ignore_them;
+pub mod kagi;
 pub mod kalman;
 pub mod kama;
 pub mod keltner;

--- a/quantwave-core/src/lib.rs
+++ b/quantwave-core/src/lib.rs
@@ -51,6 +51,7 @@ pub use indicators::harrington_adx::HarringtonADXOscillator;
 pub use indicators::heikin_ashi::HeikinAshi;
 pub use indicators::hma::HMA;
 pub use indicators::ichimoku::IchimokuCloud;
+pub use indicators::kagi::{KagiBuilder, KagiLine, kagi_atr_batch, kagi_batch};
 pub use indicators::keltner::KeltnerChannels;
 pub use indicators::market_structure::{
     Bias, FlipEvent, MarketStructure, MarketStructureState, PAEvent, PAEventKind, SwingPoint,

--- a/quantwave-py/python/quantwave/bars.py
+++ b/quantwave-py/python/quantwave/bars.py
@@ -1,4 +1,4 @@
-"""Alternative bar construction (Renko, ...).
+"""Alternative bar construction (Renko, Kagi, range bars).
 
 Bar transforms discard time and produce a different number of rows than the
 input, so they are frame-in / frame-out helpers rather than ``.ta`` expressions.
@@ -6,6 +6,8 @@ input, so they are frame-in / frame-out helpers rather than ``.ta`` expressions.
     import quantwave as qw
     bricks = qw.bars.renko(ohlcv_df, box_size=2.0)          # DataFrame[open, close, direction]
     bricks = qw.bars.renko(ohlcv_df, box_size="atr", atr_period=14, multiplier=2.0)
+    lines = qw.bars.kagi(ohlcv_df, reversal=2.0)            # DataFrame[open, close, direction, thickness]
+    bars = qw.bars.range_bars(ohlcv_df, range_size=2.0)     # DataFrame[open, high, low, close]
 """
 
 from __future__ import annotations
@@ -63,6 +65,38 @@ def renko(
         atr = _atr_value(data, price_col, atr_period)
         return _bars.renko_atr(prices, atr, multiplier)
     return _bars.renko(prices, float(box_size))
+
+
+def kagi(
+    data: "Union[pl.DataFrame, pl.LazyFrame, list[float]]",
+    reversal: "Union[float, str]" = 2.0,
+    *,
+    price_col: str = "close",
+    atr_period: int = 14,
+    multiplier: float = 1.0,
+) -> "pl.DataFrame":
+    """Build Kagi lines from a price series.
+
+    A Kagi line keeps extending in its current direction while price advances and
+    reverses only when price retraces from the running extreme by at least
+    ``reversal`` (a positive float, or ``"atr"`` to derive it from
+    ``multiplier * ATR(atr_period)``). Each row is one completed line between two
+    turning points; ``thickness`` is the yin/yang state (+1 yang, -1 yin, 0
+    undetermined).
+
+    Returns:
+        DataFrame with columns ``open``, ``close``, ``direction`` (+1/-1),
+        ``thickness`` (+1/-1/0), one row per completed line.
+    """
+    from quantwave import _bars
+
+    prices = _prices(data, price_col)
+    if isinstance(reversal, str):
+        if reversal != "atr":
+            raise ValueError("reversal must be a positive float or 'atr'")
+        atr = _atr_value(data, price_col, atr_period)
+        return _bars.kagi_atr(prices, atr, multiplier)
+    return _bars.kagi(prices, float(reversal))
 
 
 def range_bars(

--- a/quantwave-py/src/bars.rs
+++ b/quantwave-py/src/bars.rs
@@ -9,7 +9,8 @@ use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3_polars::PyDataFrame;
 use quantwave_core::{
-    RangeBar, RenkoBrick, range_bars_atr_batch, range_bars_batch, renko_atr_batch, renko_batch,
+    KagiLine, RangeBar, RenkoBrick, kagi_atr_batch, kagi_batch, range_bars_atr_batch,
+    range_bars_batch, renko_atr_batch, renko_batch,
 };
 
 fn bricks_to_frame(bricks: &[RenkoBrick]) -> PolarsResult<DataFrame> {
@@ -20,6 +21,15 @@ fn bricks_to_frame(bricks: &[RenkoBrick]) -> PolarsResult<DataFrame> {
         "open" => open,
         "close" => close,
         "direction" => direction,
+    ]
+}
+
+fn kagi_to_frame(lines: &[KagiLine]) -> PolarsResult<DataFrame> {
+    df![
+        "open" => lines.iter().map(|l| l.open).collect::<Vec<f64>>(),
+        "close" => lines.iter().map(|l| l.close).collect::<Vec<f64>>(),
+        "direction" => lines.iter().map(|l| l.direction).collect::<Vec<i8>>(),
+        "thickness" => lines.iter().map(|l| l.thickness).collect::<Vec<i8>>(),
     ]
 }
 
@@ -57,6 +67,31 @@ fn renko_atr(prices: Vec<f64>, atr: f64, multiplier: f64) -> PyResult<PyDataFram
     Ok(PyDataFrame(df))
 }
 
+/// Fixed-reversal Kagi: `prices` → DataFrame with columns
+/// open/close/direction/thickness (one row per completed line).
+#[pyfunction]
+#[pyo3(signature = (prices, reversal))]
+fn kagi(prices: Vec<f64>, reversal: f64) -> PyResult<PyDataFrame> {
+    if !(reversal > 0.0) {
+        return Err(PyValueError::new_err("reversal must be > 0"));
+    }
+    let df = kagi_to_frame(&kagi_batch(&prices, reversal))
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+    Ok(PyDataFrame(df))
+}
+
+/// ATR-reversal Kagi: reversal amount = `multiplier * atr`.
+#[pyfunction]
+#[pyo3(signature = (prices, atr, multiplier=1.0))]
+fn kagi_atr(prices: Vec<f64>, atr: f64, multiplier: f64) -> PyResult<PyDataFrame> {
+    if !(atr > 0.0) || !(multiplier > 0.0) {
+        return Err(PyValueError::new_err("atr and multiplier must be > 0"));
+    }
+    let df = kagi_to_frame(&kagi_atr_batch(&prices, atr, multiplier))
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+    Ok(PyDataFrame(df))
+}
+
 /// Constant-range bars: `prices` → DataFrame with columns open/high/low/close.
 #[pyfunction]
 #[pyo3(signature = (prices, range_size))]
@@ -84,6 +119,8 @@ fn range_bars_atr(prices: Vec<f64>, atr: f64, multiplier: f64) -> PyResult<PyDat
 pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(renko, m)?)?;
     m.add_function(wrap_pyfunction!(renko_atr, m)?)?;
+    m.add_function(wrap_pyfunction!(kagi, m)?)?;
+    m.add_function(wrap_pyfunction!(kagi_atr, m)?)?;
     m.add_function(wrap_pyfunction!(range_bars, m)?)?;
     m.add_function(wrap_pyfunction!(range_bars_atr, m)?)?;
     Ok(())

--- a/tests/python/test_bars.py
+++ b/tests/python/test_bars.py
@@ -1,4 +1,4 @@
-"""Alternative bar construction — Renko (quantwave-p2k0.9, slice 1)."""
+"""Alternative bar construction — Renko / range bars / Kagi (quantwave-p2k0.9)."""
 
 import polars as pl
 import pytest
@@ -55,6 +55,53 @@ def test_renko_invalid_box_raises():
         qw.bars.renko([10.0, 11.0], box_size=0.0)
     with pytest.raises(ValueError):
         qw.bars.renko([10.0, 11.0], box_size="bogus")
+
+
+def test_kagi_single_reversal():
+    # Anchor 10, H=2. Rise to 14, retrace to 11 (<=14-2) → up-line [10,14].
+    b = qw.bars.kagi([10.0, 12.0, 14.0, 11.0], reversal=2.0)
+    assert b.columns == ["open", "close", "direction", "thickness"]
+    assert b.height == 1
+    assert b.row(0) == (10.0, 14.0, 1, 0)
+
+
+def test_kagi_alternating_directions():
+    b = qw.bars.kagi([10.0, 14.0, 10.0, 14.0], reversal=2.0)
+    assert b["direction"].to_list() == [1, -1]
+    assert b["open"].to_list() == [10.0, 14.0]
+    assert b["close"].to_list() == [14.0, 10.0]
+
+
+def test_kagi_yang_on_higher_high():
+    # Up [10,14] (shoulder 14), down [14,11], then up past 14 to 17 → yang line.
+    b = qw.bars.kagi([10.0, 14.0, 11.0, 17.0, 14.0], reversal=2.0)
+    assert b.height == 3
+    assert b["thickness"].to_list() == [0, 0, 1]
+    assert b["direction"].to_list() == [1, -1, 1]
+
+
+def test_kagi_no_reversal_within_threshold():
+    assert qw.bars.kagi([10.0, 11.0, 10.2, 11.5, 10.8], reversal=2.0).height == 0
+
+
+def test_kagi_alternation_invariant_on_frame():
+    df = qw.datasets.synthetic(seed=7, rows=300)
+    b = qw.bars.kagi(df, reversal=2.0)
+    dirs = b["direction"].to_list()
+    # Consecutive lines strictly alternate and connect end-to-start.
+    assert all(a == -c for a, c in zip(dirs, dirs[1:]))
+    opens, closes = b["open"].to_list(), b["close"].to_list()
+    assert all(closes[i] == opens[i + 1] for i in range(len(opens) - 1))
+    assert set(b["thickness"].unique().to_list()) <= {-1, 0, 1}
+
+
+def test_kagi_atr_and_errors():
+    df = qw.datasets.synthetic(seed=8, rows=200)
+    assert qw.bars.kagi(df, reversal="atr", multiplier=2.0).height >= 0
+    with pytest.raises(Exception):
+        qw.bars.kagi([10.0, 11.0], reversal=0.0)
+    with pytest.raises(ValueError):
+        qw.bars.kagi([10.0, 11.0], reversal="bogus")
 
 
 def test_range_bars_single_bar():


### PR DESCRIPTION
## Summary

Third alternative-bar transform under `quantwave.bars` (after Renko #23 and range bars #24), completing the batch-buildable bar family for **quantwave-p2k0.9**. Same shape as the prior slices: Rust builder + batch fold + ATR variant, streaming/batch parity proptest, PyO3 `_bars` submodule, gold fixtures.

**Surface:** `qw.bars.kagi(data, reversal=… | "atr") -> DataFrame[open, close, direction, thickness]`
Core: `KagiBuilder` / `KagiLine` / `kagi_batch` / `kagi_atr_batch`.

## Spec (cited)

- **Reversal construction** (threshold `H`, true price extrema as turning points) follows **Bogomolov (2013)**, _Quantitative Finance_ 13(9):1411–1430, which formalises Kagi/Renko as model-free threshold samplers of a price path: an up-move reverses at the first price `<= running_max − H`, a down-move at the first `>= running_min + H`. This is the same paper `renko.rs` already cites for the threshold variant.
- **Yin/yang `thickness`** follows the classic Nison shoulder/waist convention (`+1` yang above prior shoulder, `−1` yin below prior waist, `0` undetermined) — the machine-readable Kagi signal, kept separate from visualization per the project's rich-Struct PA philosophy. Thickness is tied to each line's own extreme, so the reversal-triggering price (which belongs to the *next* line) can't contaminate a completing line's state.

## Tests

- **Rust:** 4 gold fixtures (single reversal, alternating directions, no-reversal-within-threshold, yang-on-higher-high) + 2 proptests (streaming == batch parity; lines alternate direction, connect end-to-start, span ≥ `H`).
- **Python:** 6 tests (gold walks, yang-on-higher-high, alternation+connection invariant on synthetic data, ATR + error paths).
- Validation stats regenerated (+6 core tests, +1 proptest block).

Gate green locally: `cargo clippy` (core/polars/backtest, `-D warnings`) clean, `cargo nextest -p quantwave-core` 563 passed, `pytest tests/python/test_bars.py` 18 passed.

Remaining p2k0.9 slices: Point & Figure, harmonic patterns (Gartley/Bat/Butterfly), docs section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)