### PR TITLE
feat(patterns): harmonic patterns (AB=CD / Alternate AB=CD / 5-0) — p2k0.9 slice 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ __pycache__/
 *.so
 quantwave-py/python/quantwave/*.so
 
+
+# Copyrighted reference material — local only, never commit (attribution lives in docs)
+/sources/
+/references/*.pdf

--- a/docs/generated/core_safety.json
+++ b/docs/generated/core_safety.json
@@ -1,6 +1,6 @@
 {
   "crate": "quantwave-core",
-  "files_scanned": 201,
+  "files_scanned": 204,
   "unsafe_forbidden": true,
   "panic_forbidden": true,
   "forbidden_violations": 0,

--- a/docs/generated/validation_stats.json
+++ b/docs/generated/validation_stats.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-19T02:27:45Z",
+  "generated_at": "2026-07-19T04:47:13Z",
   "indicator_count": 221,
   "metadata_with_gold_file": 217,
   "gold_fixture_count": 28,
@@ -36,12 +36,12 @@
   "python_gold_parity_count": 26,
   "python_gold_parity_deferred": 2,
   "rust_tests_by_package": {
-    "quantwave-core": 563,
+    "quantwave-core": 571,
     "quantwave-polars": 45,
     "quantwave-backtest": 92
   },
-  "rust_test_total": 700,
-  "proptest_blocks": 158,
+  "rust_test_total": 708,
+  "proptest_blocks": 159,
   "batch_streaming_parity_checks": 4,
   "talib_parity_test_fns": 134,
   "parity_proptest_indicators": 214,

--- a/docs/guides/indicators/bars_and_patterns.md
+++ b/docs/guides/indicators/bars_and_patterns.md
@@ -1,0 +1,123 @@
+# Bar Types & Patterns
+
+Beyond per-bar indicators, QuantWave ships **frame-in / frame-out** transforms
+that reshape a price series into alternative *bar types* or detect multi-pivot
+*chart patterns*. Because they change the row count, they are plain functions
+returning a fresh Polars `DataFrame` — not `.ta` expressions.
+
+Both families share the project's design rules: every result is a **rich,
+machine-readable struct** (kept separate from any charting), and every builder
+has a stateful streaming form that is **bit-identical** to the batch form.
+
+---
+
+## Alternative bar types (`qw.bars`)
+
+These discard time and re-sample price by movement. Each accepts an OHLCV
+`DataFrame`/`LazyFrame` (using a `price_col`, default `close`) or a raw list of
+prices, and each supports an ATR-derived threshold (`"atr"`).
+
+| Function | Bar rule | Columns | Source |
+|---|---|---|---|
+| `qw.bars.renko` | Fixed box `ΔP`; a new brick when close leaves the band | `open, close, direction` | Drozda, Cavojsky, Sebes (2024), *On Suitability of Renko Charts for Algorithmic Trading*, Def. 1 |
+| `qw.bars.range_bars` | Bar closes when high−low span reaches `range_size` | `open, high, low, close` | Constant-range (constant-range bar) construction |
+| `qw.bars.kagi` | Line reverses when price retraces `reversal` from the extreme | `open, close, direction, thickness` | Bogomolov (2013) reversal construction + Nison yin/yang |
+
+```python
+import quantwave as qw
+
+df = qw.datasets.synthetic(seed=3, rows=300)
+
+bricks = qw.bars.renko(df, box_size=2.0)              # or box_size="atr"
+bars   = qw.bars.range_bars(df, range_size=3.0)
+lines  = qw.bars.kagi(df, reversal=2.0)               # thickness: +1 yang / -1 yin / 0
+```
+
+The Kagi `thickness` column is the classic **yin/yang** signal: `+1` (yang) once
+price rises above the prior shoulder, `-1` (yin) once it falls below the prior
+waist — the machine-readable form of Kagi's line-weight convention.
+
+---
+
+## Harmonic patterns (`qw.patterns.harmonic`)
+
+Harmonic patterns are Fibonacci-ratio-constrained price structures. The detector
+is built on the shared **MarketStructure** swing foundation: confirmed swing
+pivots are tested against each pattern's ratio gates, and a pattern is reported
+only once its completion pivot `D` is a *confirmed* swing. Detection therefore
+uses no information from beyond `D` — it is **anti-lookahead** by construction
+(the reported `d_bar` never sits after the bar at which the pattern is emitted).
+
+### Attribution
+
+> Harmonic Trading is the work of **Scott M. Carney** (HarmonicTrader.com).
+> Carney named and defined these patterns; **"Harmonic Trading" and several
+> pattern names (including the 5-0) are trademarks of Scott M. Carney /
+> HarmonicTrader.com.** QuantWave implements his published Fibonacci-ratio
+> definitions for interoperability, with attribution, and reproduces no source
+> text. The string is also available at `qw.patterns.HARMONIC_ATTRIBUTION`.
+
+Ratio definitions follow:
+
+- **AB=CD** and **Alternate AB=CD** — Carney, *Harmonic Trading: Volume One*
+  (2010), Ch. 4 "The AB=CD Pattern", and [harmonictrader.com › AB=CD](https://harmonictrader.com/harmonic-patterns/abcd-pattern/)
+  / [Alternate ABCD](https://harmonictrader.com/harmonic-patterns/alternate-abcd-pattern/).
+- **5-0** — Carney, *Harmonic Trading: Volume Two* (2010), Ch. 3 "New Harmonic
+  Patterns", pp. 78–79, and [harmonictrader.com › 5-0](https://harmonictrader.com/harmonic-patterns/5-0/).
+
+### Patterns and ratios
+
+| Pattern (`kind`) | Points | Ratio gates |
+|---|---|---|
+| `abcd` | A, B, C, D | C retraces AB by 0.382–0.886; **CD = AB** (equal length) |
+| `alternate_abcd` | A, B, C, D | C retraces AB by 0.382–0.886; **CD = 1.27 × AB or 1.618 × AB** |
+| `5-0` | X, A, B, C, D | B = 1.13–1.618 of XA; C = 1.618–2.24 of AB; **D = 50% of BC** and the reciprocal AB=CD |
+
+The AB=CD reciprocal table (C retracement `{0.382, 0.50, 0.618, 0.707, 0.786,
+0.886}` pairs with the BC projection `{2.618/2.24, 2.0, 1.618, 1.41, 1.27,
+1.13}`) is applied via the equal-length CD constraint.
+
+### Usage
+
+```python
+import polars as pl
+import quantwave as qw
+
+df = qw.datasets.synthetic(seed=7, rows=500)          # needs high/low columns
+
+pats = qw.patterns.harmonic(
+    df,
+    swing_strength=5,        # swing-pivot window (larger → fewer, bigger pivots)
+    ratio_tolerance=0.10,    # ±10% on the Fibonacci ratios
+    min_score=0.5,           # ratio-fit quality threshold (0-1)
+)
+
+# Only bullish 5-0 setups, most textbook-exact first
+setups = pats.filter(
+    (pl.col("kind") == "5-0") & pl.col("is_bull")
+).sort("score", descending=True)
+```
+
+### Output schema
+
+One row per detected pattern:
+
+| Column | Meaning |
+|---|---|
+| `id`, `kind`, `is_bull` | sequence id, pattern type, buy (`true`) vs sell setup |
+| `x_bar` … `d_bar`, `x_price` … `d_price` | pivot bars and prices (`x_*` is null for AB=CD) |
+| `score` | ratio-fit quality in `[0, 1]` (1.0 = textbook-exact) |
+| `xa_ext`, `bc_ab`, `cd_ab`, `cd_bc` | the measured leg ratios |
+| `prz_low`, `prz_high` | Potential Reversal Zone (projected completion band) |
+| `size_atr` | pattern vertical extent in ATR units (for sizing / filtering) |
+
+Pass a `(highs, lows)` tuple instead of a frame if you already have the arrays.
+Toggle families with `detect_abcd` / `detect_alternate_abcd` / `detect_5_0`.
+
+---
+
+## See also
+
+- [Indicator Gallery](gallery.md) · [Full Catalog](native/index.md)
+- Market Structure and Geometric Patterns (Flags, Head & Shoulders) build on the
+  same swing foundation.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -7,7 +7,7 @@ QuantWave's primary credibility claim is **correctness**: one mathematical imple
 ## Coverage snapshot
 
 <!-- VALIDATION:STATS:START -->
-**Last updated:** 2026-07-19T02:27:45Z (UTC)
+**Last updated:** 2026-07-19T04:47:13Z (UTC)
 
 | Metric | Count | Source |
 |--------|------:|--------|
@@ -16,11 +16,11 @@ QuantWave's primary credibility claim is **correctness**: one mathematical imple
 | Gold-standard JSON fixtures (on disk) | **28** | `quantwave-core/tests/gold_standard/` |
 | Python streaming gold parity cases | **26** | `tests/python/gold_parity_registry.py` |
 | Python gold parity deferred (HMM) | 2 | regime fixtures — separate suite |
-| Rust `#[test]` functions (core) | 563 | `rg '#[test]' quantwave-core` |
+| Rust `#[test]` functions (core) | 571 | `rg '#[test]' quantwave-core` |
 | Rust `#[test]` functions (polars) | 45 | `rg '#[test]' quantwave-polars` |
 | Rust `#[test]` functions (backtest) | 92 | `rg '#[test]' quantwave-backtest` |
-| Rust tests (total, 3 crates) | **700** | sum of above |
-| `proptest!` blocks (core) | **158** | `rg 'proptest!\{' quantwave-core` |
+| Rust tests (total, 3 crates) | **708** | sum of above |
+| `proptest!` blocks (core) | **159** | `rg 'proptest!\{' quantwave-core` |
 | `check_batch_streaming_parity` call sites | 4 | indicator modules |
 | TA-Lib parity test functions | 134 | `test_*_talib_parity.rs` |
 | Indicators with proptest parity (CI-enforced) | **214** | `check_indicator_parity_coverage.py` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
       - Overview: guides/indicators/index.md
       - Gallery: guides/indicators/gallery.md
       - Full Catalog: guides/indicators/native/index.md
+      - Bar Types & Patterns: guides/indicators/bars_and_patterns.md
       - Ehlers DSP: guides/indicators/ehlers/index.md
       - Regime Detection: guides/indicators/regimes/index.md
       - ML Features: guides/ml_features.md

--- a/quantwave-core/proptest-regressions/indicators/harmonic.txt
+++ b/quantwave-core/proptest-regressions/indicators/harmonic.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 431b65488040680dd04726ebb3632d8a6d3832b20dfafe19a74bd1c5eed1342f # shrinks to hl = [(0.0, 0.0), (634.6729408432024, 483.44904025239435), (999.8705732934192, 466.4673889636023), (94.96256941171784, 303.80674503401264), (148.98304760892265, 793.4700197423822), (553.4698861814157, 608.355266033503), (859.7124149019292, 725.9105879444694), (947.33711079599, 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0)]

--- a/quantwave-core/src/indicators/harmonic.rs
+++ b/quantwave-core/src/indicators/harmonic.rs
@@ -1,0 +1,696 @@
+//! Harmonic pattern detection (AB=CD, Alternate AB=CD, 5-0).
+//!
+//! Harmonic patterns are Fibonacci-ratio-constrained price structures. This
+//! module implements three of them, built on the shared swing foundation
+//! ([`MarketStructure`], Part 21) exactly like [`GeometricPatternScanner`]:
+//! confirmed swing pivots are collected into an alternating sequence, and the
+//! most recent 4 (AB=CD) or 5 (5-0) pivots are tested against the pattern's
+//! ratio gates. A pattern is emitted only once its completion pivot `D` is a
+//! *confirmed* swing — which lags the pivot by `swing_strength` bars — so
+//! detection never uses information from beyond `D` (anti-lookahead).
+//!
+//! # Attribution
+//!
+//! Harmonic Trading is the work of **Scott M. Carney** (HarmonicTrader.com).
+//! Carney named and defined these patterns; "Harmonic Trading" and several
+//! pattern names are his trademarks. The ratio definitions here follow his
+//! primary sources and are implemented for interoperability with attribution —
+//! no source text is reproduced:
+//!
+//! - AB=CD reciprocal ratio table (C retracement {0.382, 0.50, 0.618, 0.707,
+//!   0.786, 0.886} ↔ BC projection {2.618/2.24, 2.0, 1.618, 1.41, 1.27, 1.13}):
+//!   Carney, *Harmonic Trading: Volume One* (2010), Ch. 4 "The AB=CD Pattern".
+//! - Alternate AB=CD (CD = 1.27 or 1.618 × AB): *Volume One* Ch. 4 /
+//!   harmonictrader.com "Alternate ABCD Pattern".
+//! - 5-0 pattern (B = 1.13–1.618 of XA; C = 1.618–2.24 of AB; D = 50% of BC and
+//!   the reciprocal AB=CD): Carney, *Harmonic Trading: Volume Two* (2010),
+//!   Ch. 3 "New Harmonic Patterns", pp. 78–79 / harmonictrader.com "5-0".
+//!
+//! Signal output is a rich [`HarmonicPattern`] struct (pivots, measured ratios,
+//! fit score, PRZ), kept separate from any visualization per the project's PA
+//! design philosophy.
+
+use crate::indicators::market_structure::{MarketStructure, SwingPoint};
+use crate::traits::Next;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+/// Which harmonic pattern was detected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum HarmonicKind {
+    /// AB=CD: CD leg equals AB in length.
+    AbCd,
+    /// Alternate AB=CD: CD = 1.27 × AB or 1.618 × AB.
+    AlternateAbCd,
+    /// 5-0: five-point structure completing at a 50% BC retrace / reciprocal AB=CD.
+    FiveZero,
+}
+
+impl HarmonicKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            HarmonicKind::AbCd => "abcd",
+            HarmonicKind::AlternateAbCd => "alternate_abcd",
+            HarmonicKind::FiveZero => "5-0",
+        }
+    }
+
+    fn discriminant(&self) -> u8 {
+        match self {
+            HarmonicKind::AbCd => 0,
+            HarmonicKind::AlternateAbCd => 1,
+            HarmonicKind::FiveZero => 2,
+        }
+    }
+}
+
+/// A detected harmonic pattern. Points are labelled X, A, B, C, D; `x_*` is
+/// populated only for the 5-0 (four-point AB=CD patterns have no X). `is_bull`
+/// is true when the pattern completes at a low (a buy setup).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HarmonicPattern {
+    pub id: u32,
+    pub kind: HarmonicKind,
+    pub is_bull: bool,
+    pub x_bar: Option<usize>,
+    pub x_price: Option<f64>,
+    pub a_bar: usize,
+    pub a_price: f64,
+    pub b_bar: usize,
+    pub b_price: f64,
+    pub c_bar: usize,
+    pub c_price: f64,
+    pub d_bar: usize,
+    pub d_price: f64,
+    /// Ratio-fit quality in [0, 1]; 1.0 is a textbook-exact pattern.
+    pub score: f64,
+    /// 5-0 only: |AB| / |XA| (the B-point extension of XA).
+    pub xa_ext: Option<f64>,
+    /// |BC| / |AB| — a retracement (< 1) for AB=CD, an extension (> 1) for 5-0.
+    pub bc_ab: f64,
+    /// |CD| / |AB| — 1.0 for AB=CD, 1.27/1.618 for Alternate, ~1.0 for 5-0.
+    pub cd_ab: f64,
+    /// |CD| / |BC| — ~0.5 for the 5-0 completion.
+    pub cd_bc: f64,
+    /// Potential Reversal Zone (price band where the pattern projects to complete).
+    pub prz_low: f64,
+    pub prz_high: f64,
+    /// Vertical extent of the pattern (max − min pivot price) in ATR units.
+    pub size_atr: f64,
+}
+
+/// Tunable detection thresholds.
+#[derive(Debug, Clone)]
+pub struct HarmonicConfig {
+    /// Relative tolerance on equality ratios and range-gate edges (e.g. 0.10 = ±10%).
+    pub ratio_tolerance: f64,
+    /// Minimum fit score to emit a pattern.
+    pub min_score: f64,
+    /// Minimum pattern extent in ATR units (0.0 disables the filter).
+    pub min_size_atr: f64,
+    pub atr_period: usize,
+    pub detect_abcd: bool,
+    pub detect_alternate_abcd: bool,
+    pub detect_5_0: bool,
+}
+
+impl Default for HarmonicConfig {
+    fn default() -> Self {
+        Self {
+            ratio_tolerance: 0.10,
+            min_score: 0.5,
+            min_size_atr: 0.0,
+            atr_period: 14,
+            detect_abcd: true,
+            detect_alternate_abcd: true,
+            detect_5_0: true,
+        }
+    }
+}
+
+/// 1.0 when `measured == ideal`, decreasing linearly to 0 at `±tol` relative.
+fn ratio_fit(measured: f64, ideal: f64, tol: f64) -> f64 {
+    if ideal == 0.0 || tol <= 0.0 {
+        return 0.0;
+    }
+    let err = (measured / ideal - 1.0).abs();
+    (1.0 - err / tol).clamp(0.0, 1.0)
+}
+
+/// Whether `x` lies within `[lo, hi]` after expanding the edges by `tol` relative.
+fn in_band(x: f64, lo: f64, hi: f64, tol: f64) -> bool {
+    x >= lo * (1.0 - tol) && x <= hi * (1.0 + tol)
+}
+
+fn leg(a: f64, b: f64) -> f64 {
+    (a - b).abs()
+}
+
+/// Streaming harmonic pattern scanner. Feed `(high, low)` per bar; each call
+/// returns the patterns (usually none) whose completion pivot confirmed on that
+/// bar.
+#[derive(Debug, Clone)]
+pub struct HarmonicPatternScanner {
+    ms: MarketStructure,
+    config: HarmonicConfig,
+    bar_index: usize,
+    prev_close: f64,
+    have_prev_close: bool,
+    atr: f64,
+    swings: Vec<SwingPoint>,
+    /// Bar of the last high/low pivot already ingested, so each confirmed pivot
+    /// is appended exactly once (not re-read every bar while it stays current).
+    last_high_bar: Option<usize>,
+    last_low_bar: Option<usize>,
+    seen: HashSet<(u8, usize, usize, usize, usize)>,
+    next_id: u32,
+}
+
+impl HarmonicPatternScanner {
+    pub fn new(swing_strength: usize) -> Self {
+        Self::with_config(swing_strength, HarmonicConfig::default())
+    }
+
+    pub fn with_config(swing_strength: usize, config: HarmonicConfig) -> Self {
+        Self {
+            ms: MarketStructure::new(swing_strength),
+            config,
+            bar_index: 0,
+            prev_close: 0.0,
+            have_prev_close: false,
+            atr: 1.0,
+            swings: Vec::with_capacity(64),
+            last_high_bar: None,
+            last_low_bar: None,
+            seen: HashSet::new(),
+            next_id: 1,
+        }
+    }
+
+    fn update_atr(&mut self, high: f64, low: f64) {
+        let prev_close = if self.have_prev_close {
+            self.prev_close
+        } else {
+            (high + low) / 2.0
+        };
+        let tr = (high - low)
+            .max((high - prev_close).abs())
+            .max((low - prev_close).abs());
+        let p = self.config.atr_period.max(1);
+        if self.bar_index <= p {
+            // Seed with a simple mean until the window fills.
+            let n = self.bar_index as f64;
+            self.atr = (self.atr * (n - 1.0) + tr) / n.max(1.0);
+        } else {
+            let alpha = 1.0 / p as f64;
+            self.atr = self.atr * (1.0 - alpha) + tr * alpha;
+        }
+        self.atr = self.atr.max(1e-8);
+    }
+
+    /// Append a confirmed swing, keeping the sequence strictly alternating (a
+    /// same-direction pivot replaces the previous one when it is more extreme).
+    fn ingest_swing(&mut self, sp: &SwingPoint) {
+        if let Some(last) = self.swings.last() {
+            if last.bar == sp.bar && last.is_high == sp.is_high {
+                return;
+            }
+            if last.is_high == sp.is_high {
+                let more_extreme = (sp.is_high && sp.price >= last.price)
+                    || (!sp.is_high && sp.price <= last.price);
+                if more_extreme {
+                    self.swings.pop();
+                } else {
+                    return;
+                }
+            }
+        }
+        self.swings.push(sp.clone());
+        if self.swings.len() > 64 {
+            self.swings.drain(0..16);
+        }
+    }
+
+    fn size_atr(&self, prices: &[f64]) -> f64 {
+        let hi = prices.iter().cloned().fold(f64::MIN, f64::max);
+        let lo = prices.iter().cloned().fold(f64::MAX, f64::min);
+        (hi - lo) / self.atr
+    }
+
+    fn emit(&mut self, mut p: HarmonicPattern) -> Option<HarmonicPattern> {
+        if p.score < self.config.min_score || p.size_atr < self.config.min_size_atr {
+            return None;
+        }
+        let key = (
+            p.kind.discriminant(),
+            p.x_bar.unwrap_or(usize::MAX),
+            p.a_bar,
+            p.c_bar,
+            p.d_bar,
+        );
+        if !self.seen.insert(key) {
+            return None;
+        }
+        p.id = self.next_id;
+        self.next_id += 1;
+        Some(p)
+    }
+
+    /// Test the last four swings (A, B, C, D) as a (possibly Alternate) AB=CD.
+    fn classify_abcd(
+        &self,
+        a: &SwingPoint,
+        b: &SwingPoint,
+        c: &SwingPoint,
+        d: &SwingPoint,
+    ) -> Option<HarmonicPattern> {
+        // Pivots must be strictly time-ordered (MarketStructure can occasionally
+        // report a high and a low on the same bar for degenerate windows).
+        if !(a.bar < b.bar && b.bar < c.bar && c.bar < d.bar) {
+            return None;
+        }
+        let ab = leg(a.price, b.price);
+        let bc = leg(b.price, c.price);
+        let cd = leg(c.price, d.price);
+        if ab <= 0.0 || bc <= 0.0 || cd <= 0.0 {
+            return None;
+        }
+        let bc_ab = bc / ab;
+        let cd_ab = cd / ab;
+        let tol = self.config.ratio_tolerance;
+        // C must be a retracement of AB (0.382–0.886 per the reciprocal table).
+        if !in_band(bc_ab, 0.382, 0.886, tol) {
+            return None;
+        }
+        let is_bull = !d.is_high;
+
+        let (kind, target) = if self.config.detect_abcd && ratio_fit(cd_ab, 1.0, tol) > 0.0 {
+            (HarmonicKind::AbCd, 1.0)
+        } else if self.config.detect_alternate_abcd {
+            let nearest = if (cd_ab - 1.27).abs() <= (cd_ab - 1.618).abs() {
+                1.27
+            } else {
+                1.618
+            };
+            if ratio_fit(cd_ab, nearest, tol) > 0.0 {
+                (HarmonicKind::AlternateAbCd, nearest)
+            } else {
+                return None;
+            }
+        } else {
+            return None;
+        };
+
+        let score = ratio_fit(cd_ab, target, tol);
+        // PRZ: the AB=CD completion price (target × AB projected from C), banded.
+        let sign = if is_bull { -1.0 } else { 1.0 };
+        let d_proj = c.price + sign * target * ab;
+        let band = tol * ab;
+        Some(HarmonicPattern {
+            id: 0,
+            kind,
+            is_bull,
+            x_bar: None,
+            x_price: None,
+            a_bar: a.bar,
+            a_price: a.price,
+            b_bar: b.bar,
+            b_price: b.price,
+            c_bar: c.bar,
+            c_price: c.price,
+            d_bar: d.bar,
+            d_price: d.price,
+            score,
+            xa_ext: None,
+            bc_ab,
+            cd_ab,
+            cd_bc: cd / bc,
+            prz_low: d_proj - band,
+            prz_high: d_proj + band,
+            size_atr: self.size_atr(&[a.price, b.price, c.price, d.price]),
+        })
+    }
+
+    /// Test the last five swings (X, A, B, C, D) as a 5-0.
+    fn classify_5_0(
+        &self,
+        x: &SwingPoint,
+        a: &SwingPoint,
+        b: &SwingPoint,
+        c: &SwingPoint,
+        d: &SwingPoint,
+    ) -> Option<HarmonicPattern> {
+        if !self.config.detect_5_0 {
+            return None;
+        }
+        if !(x.bar < a.bar && a.bar < b.bar && b.bar < c.bar && c.bar < d.bar) {
+            return None;
+        }
+        let xa = leg(x.price, a.price);
+        let ab = leg(a.price, b.price);
+        let bc = leg(b.price, c.price);
+        let cd = leg(c.price, d.price);
+        if xa <= 0.0 || ab <= 0.0 || bc <= 0.0 || cd <= 0.0 {
+            return None;
+        }
+        let xa_ext = ab / xa;
+        let bc_ab = bc / ab;
+        let cd_bc = cd / bc;
+        let cd_ab = cd / ab;
+        let tol = self.config.ratio_tolerance;
+        // B = 1.13–1.618 of XA; C = 1.618–2.24 of AB; D = 50% of BC.
+        if !in_band(xa_ext, 1.13, 1.618, tol)
+            || !in_band(bc_ab, 1.618, 2.24, tol)
+            || ratio_fit(cd_bc, 0.5, tol) == 0.0
+        {
+            return None;
+        }
+        let is_bull = !d.is_high;
+        // D is defined by both the 50% BC retrace and the reciprocal AB=CD; score
+        // rewards proximity to both (the reciprocal on a looser band, as it only
+        // "complements" the PRZ per Vol. 2).
+        let score = 0.5 * ratio_fit(cd_bc, 0.5, tol) + 0.5 * ratio_fit(cd_ab, 1.0, tol * 1.5);
+        // PRZ spans the two projections from C: 50% of BC and the reciprocal AB=CD.
+        let sign = if is_bull { -1.0 } else { 1.0 };
+        let lvl_50 = c.price + sign * 0.5 * bc;
+        let lvl_abcd = c.price + sign * ab;
+        Some(HarmonicPattern {
+            id: 0,
+            kind: HarmonicKind::FiveZero,
+            is_bull,
+            x_bar: Some(x.bar),
+            x_price: Some(x.price),
+            a_bar: a.bar,
+            a_price: a.price,
+            b_bar: b.bar,
+            b_price: b.price,
+            c_bar: c.bar,
+            c_price: c.price,
+            d_bar: d.bar,
+            d_price: d.price,
+            score,
+            xa_ext: Some(xa_ext),
+            bc_ab,
+            cd_ab,
+            cd_bc,
+            prz_low: lvl_50.min(lvl_abcd),
+            prz_high: lvl_50.max(lvl_abcd),
+            size_atr: self.size_atr(&[x.price, a.price, b.price, c.price, d.price]),
+        })
+    }
+
+    fn detect(&mut self) -> Vec<HarmonicPattern> {
+        let mut out = Vec::new();
+        let n = self.swings.len();
+        if n >= 5 {
+            let (x, a, b, c, d) = (
+                self.swings[n - 5].clone(),
+                self.swings[n - 4].clone(),
+                self.swings[n - 3].clone(),
+                self.swings[n - 2].clone(),
+                self.swings[n - 1].clone(),
+            );
+            if let Some(p) = self.classify_5_0(&x, &a, &b, &c, &d)
+                && let Some(p) = self.emit(p)
+            {
+                out.push(p);
+            }
+        }
+        if n >= 4 {
+            let (a, b, c, d) = (
+                self.swings[n - 4].clone(),
+                self.swings[n - 3].clone(),
+                self.swings[n - 2].clone(),
+                self.swings[n - 1].clone(),
+            );
+            if let Some(p) = self.classify_abcd(&a, &b, &c, &d)
+                && let Some(p) = self.emit(p)
+            {
+                out.push(p);
+            }
+        }
+        out
+    }
+}
+
+impl Next<(f64, f64)> for HarmonicPatternScanner {
+    type Output = Vec<HarmonicPattern>;
+
+    fn next(&mut self, (high, low): (f64, f64)) -> Self::Output {
+        self.bar_index += 1;
+        self.update_atr(high, low);
+        self.prev_close = (high + low) / 2.0;
+        self.have_prev_close = true;
+
+        let state = self.ms.next((high, low));
+        // Ingest a pivot only when newly confirmed (its bar changed since last
+        // seen), so each pivot enters the sequence once, in confirmation order.
+        if let Some(sh) = state.last_swing_high.clone()
+            && self.last_high_bar != Some(sh.bar)
+        {
+            self.last_high_bar = Some(sh.bar);
+            self.ingest_swing(&sh);
+        }
+        if let Some(sl) = state.last_swing_low.clone()
+            && self.last_low_bar != Some(sl.bar)
+        {
+            self.last_low_bar = Some(sl.bar);
+            self.ingest_swing(&sl);
+        }
+        self.detect()
+    }
+}
+
+/// Batch harmonic detection: fold [`HarmonicPatternScanner`] over `(high, low)`
+/// bars, returning every detected pattern in completion order.
+pub fn harmonic_patterns_batch(
+    bars: &[(f64, f64)],
+    swing_strength: usize,
+    config: HarmonicConfig,
+) -> Vec<HarmonicPattern> {
+    let mut s = HarmonicPatternScanner::with_config(swing_strength, config);
+    let mut out = Vec::new();
+    for &(h, l) in bars {
+        out.extend(s.next((h, l)));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    const STRENGTH: usize = 2;
+    const SPACING: usize = 6;
+
+    /// Build an OHLC `(high, low)` series whose confirmed swings land exactly on
+    /// the given pivots. Prices ramp piecewise-linearly between pivots so each is
+    /// a strict local extreme detectable by `MarketStructure` at `STRENGTH`.
+    fn series_from_pivots(pivots: &[(f64, bool)]) -> Vec<(f64, f64)> {
+        let eps = 0.01;
+        let start = STRENGTH + 1;
+        let n = start + (pivots.len() - 1) * SPACING + STRENGTH + 2;
+        let bars: Vec<usize> = (0..pivots.len()).map(|i| start + i * SPACING).collect();
+        let mut out = Vec::with_capacity(n);
+        for i in 0..n {
+            // Interpolate the "mid path" through the pivot prices at this bar.
+            let mid = if i <= bars[0] {
+                pivots[0].0
+            } else if i >= *bars.last().unwrap() {
+                pivots.last().unwrap().0
+            } else {
+                let k = bars.iter().position(|&b| b > i).unwrap();
+                let (b0, b1) = (bars[k - 1], bars[k]);
+                let (v0, v1) = (pivots[k - 1].0, pivots[k].0);
+                v0 + (v1 - v0) * (i - b0) as f64 / (b1 - b0) as f64
+            };
+            out.push((mid + eps, mid - eps));
+        }
+        for (idx, &(price, is_high)) in pivots.iter().enumerate() {
+            let bar = bars[idx];
+            if is_high {
+                out[bar] = (price, price - 2.0 * eps);
+            } else {
+                out[bar] = (price + 2.0 * eps, price);
+            }
+        }
+        out
+    }
+
+    fn run(pivots: &[(f64, bool)]) -> Vec<HarmonicPattern> {
+        harmonic_patterns_batch(
+            &series_from_pivots(pivots),
+            STRENGTH,
+            HarmonicConfig::default(),
+        )
+    }
+
+    #[test]
+    fn gold_bullish_abcd_exact() {
+        // Bullish AB=CD: A high, B low, C high (0.618 retrace of AB), D low with
+        // CD = AB. A=110, B=100 (AB=10), C=106.18 (0.618 up), D=96.18 (CD=10).
+        let pats = run(&[
+            (110.0, true),
+            (100.0, false),
+            (106.18, true),
+            (96.18, false),
+        ]);
+        let abcd: Vec<_> = pats
+            .iter()
+            .filter(|p| p.kind == HarmonicKind::AbCd)
+            .collect();
+        assert_eq!(abcd.len(), 1, "exactly one AB=CD");
+        let p = abcd[0];
+        assert!(p.is_bull);
+        assert!(p.score > 0.95, "near-exact score, got {}", p.score);
+        assert!((p.cd_ab - 1.0).abs() < 0.02);
+        assert!((p.bc_ab - 0.618).abs() < 0.02);
+        assert_eq!(p.x_bar, None);
+    }
+
+    #[test]
+    fn gold_alternate_abcd_1_27() {
+        // Same A,B,C but CD = 1.27 × AB → D = 106.18 − 12.7 = 93.48.
+        let pats = run(&[
+            (110.0, true),
+            (100.0, false),
+            (106.18, true),
+            (93.48, false),
+        ]);
+        let alt: Vec<_> = pats
+            .iter()
+            .filter(|p| p.kind == HarmonicKind::AlternateAbCd)
+            .collect();
+        assert_eq!(alt.len(), 1, "one Alternate AB=CD");
+        assert!((alt[0].cd_ab - 1.27).abs() < 0.03);
+        assert!(alt[0].score > 0.9);
+    }
+
+    #[test]
+    fn gold_bullish_5_0_exact() {
+        // 5-0: X low, A high, B low (AB = 1.618×XA), C high (BC = 2.0×AB), D low
+        // (CD = 0.5×BC = AB, both projections agree → score ~1).
+        // X=100, A=110 (XA=10), B=93.82 (AB=16.18=1.618×10), C=126.18 (BC=32.36
+        // =2.0×AB), D=110.0 (CD=16.18=0.5×BC=AB).
+        let pats = run(&[
+            (100.0, false),
+            (110.0, true),
+            (93.82, false),
+            (126.18, true),
+            (110.0, false),
+        ]);
+        let five: Vec<_> = pats
+            .iter()
+            .filter(|p| p.kind == HarmonicKind::FiveZero)
+            .collect();
+        assert_eq!(five.len(), 1, "one 5-0");
+        let p = five[0];
+        assert!(p.is_bull);
+        assert!(p.x_bar.is_some());
+        assert!((p.cd_bc - 0.5).abs() < 0.03, "cd_bc {}", p.cd_bc);
+        assert!(p.score > 0.9, "score {}", p.score);
+    }
+
+    #[test]
+    fn perturbed_abcd_rejected() {
+        // CD = 1.5 × AB is neither 1.0 (AB=CD) nor 1.27/1.618 (Alternate) within
+        // 10% → no pattern. C=106.18, D = 106.18 − 15 = 91.18.
+        let pats = run(&[
+            (110.0, true),
+            (100.0, false),
+            (106.18, true),
+            (91.18, false),
+        ]);
+        assert!(
+            pats.iter().all(|p| p.kind == HarmonicKind::FiveZero),
+            "no AB=CD family should match cd_ab=1.5"
+        );
+    }
+
+    #[test]
+    fn bad_retrace_rejected() {
+        // C retraces AB by only 0.2 (< 0.382 gate) → not an AB=CD candidate.
+        // A=110, B=100, C=102 (0.2), D=92 (CD=10).
+        let pats = run(&[(110.0, true), (100.0, false), (102.0, true), (92.0, false)]);
+        assert!(pats.iter().all(|p| p.kind != HarmonicKind::AbCd));
+    }
+
+    #[test]
+    fn detection_is_anti_lookahead() {
+        // The reported completion bar D must exist before detection: emission bar
+        // (index in the folded stream) is >= d_bar for every pattern.
+        let series = series_from_pivots(&[
+            (110.0, true),
+            (100.0, false),
+            (106.18, true),
+            (96.18, false),
+        ]);
+        let mut s = HarmonicPatternScanner::new(STRENGTH);
+        for (i, &(h, l)) in series.iter().enumerate() {
+            for p in s.next((h, l)) {
+                assert!(
+                    i >= p.d_bar,
+                    "pattern emitted at bar {} before its D at {}",
+                    i,
+                    p.d_bar
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn bearish_abcd_detected() {
+        // Mirror of the bullish case: A low, B high, C low, D high.
+        let pats = run(&[(90.0, false), (100.0, true), (93.82, false), (103.82, true)]);
+        let abcd: Vec<_> = pats
+            .iter()
+            .filter(|p| p.kind == HarmonicKind::AbCd)
+            .collect();
+        assert_eq!(abcd.len(), 1);
+        assert!(!abcd[0].is_bull);
+    }
+
+    proptest! {
+        // On arbitrary bars, every emitted pattern must satisfy the universal
+        // invariants: anti-lookahead (detection bar >= D), ordered/labelled
+        // pivots, a score above threshold, and ratios consistent with its kind.
+        #[test]
+        fn emitted_patterns_are_well_formed(
+            hl in prop::collection::vec((0.0f64..1000.0, 0.0f64..1000.0), 20..400),
+        ) {
+            let bars: Vec<(f64, f64)> = hl
+                .into_iter()
+                .map(|(a, b)| (a.max(b), a.min(b)))
+                .collect();
+            let mut s = HarmonicPatternScanner::new(STRENGTH);
+            let cfg = HarmonicConfig::default();
+            for (i, &(h, l)) in bars.iter().enumerate() {
+                for p in s.next((h, l)) {
+                    prop_assert!(i >= p.d_bar, "lookahead: emitted at {} for D {}", i, p.d_bar);
+                    prop_assert!(p.a_bar < p.b_bar && p.b_bar < p.c_bar && p.c_bar < p.d_bar);
+                    prop_assert!(p.score >= cfg.min_score);
+                    prop_assert!(p.prz_low <= p.prz_high);
+                    match p.kind {
+                        HarmonicKind::AbCd => {
+                            prop_assert!(in_band(p.bc_ab, 0.382, 0.886, cfg.ratio_tolerance));
+                            prop_assert!(ratio_fit(p.cd_ab, 1.0, cfg.ratio_tolerance) > 0.0);
+                            prop_assert!(p.x_bar.is_none());
+                        }
+                        HarmonicKind::AlternateAbCd => {
+                            prop_assert!(in_band(p.bc_ab, 0.382, 0.886, cfg.ratio_tolerance));
+                            let f127 = ratio_fit(p.cd_ab, 1.27, cfg.ratio_tolerance);
+                            let f1618 = ratio_fit(p.cd_ab, 1.618, cfg.ratio_tolerance);
+                            prop_assert!(f127 > 0.0 || f1618 > 0.0);
+                        }
+                        HarmonicKind::FiveZero => {
+                            prop_assert!(p.x_bar.is_some());
+                            prop_assert!(in_band(p.bc_ab, 1.618, 2.24, cfg.ratio_tolerance));
+                            prop_assert!(ratio_fit(p.cd_bc, 0.5, cfg.ratio_tolerance) > 0.0);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/quantwave-core/src/indicators/mod.rs
+++ b/quantwave-core/src/indicators/mod.rs
@@ -49,6 +49,7 @@ pub mod griffiths_predictor;
 pub mod griffiths_spectrum;
 pub mod hamming;
 pub mod hann;
+pub mod harmonic;
 pub mod harrington_adx;
 pub mod heikin_ashi;
 pub mod high_pass;

--- a/quantwave-core/src/lib.rs
+++ b/quantwave-core/src/lib.rs
@@ -47,6 +47,9 @@ pub use indicators::frac_diff::FracDiff;
 pub use indicators::fractals::BillWilliamsFractals;
 pub use indicators::gap_momentum::GapMomentum;
 pub use indicators::geometric_patterns::{FlagPattern, GeometricPatternScanner, HsPattern};
+pub use indicators::harmonic::{
+    HarmonicConfig, HarmonicKind, HarmonicPattern, HarmonicPatternScanner, harmonic_patterns_batch,
+};
 pub use indicators::harrington_adx::HarringtonADXOscillator;
 pub use indicators::heikin_ashi::HeikinAshi;
 pub use indicators::hma::HMA;

--- a/quantwave-py/python/quantwave/__init__.py
+++ b/quantwave-py/python/quantwave/__init__.py
@@ -150,6 +150,16 @@ except Exception as _e:  # pragma: no cover
         f"use `pip install \"quantwave[polars]\"`): {_e}"
     )
 
+# Price-action pattern detection (harmonic) — frame-in/frame-out helpers built
+# on the native _patterns submodule; guarded like the other polars-dependent ones.
+try:
+    from . import patterns  # noqa: F401
+except Exception as _e:  # pragma: no cover
+    warnings.warn(
+        f"quantwave.patterns unavailable (requires polars; "
+        f"use `pip install \"quantwave[polars]\"`): {_e}"
+    )
+
 # Portfolio optimization (numpy) — guarded so `import quantwave` survives the
 # core install without numpy.
 try:

--- a/quantwave-py/python/quantwave/patterns.py
+++ b/quantwave-py/python/quantwave/patterns.py
@@ -1,0 +1,118 @@
+"""Price-action pattern detection (harmonic patterns).
+
+Pattern detectors return a variable number of detected-pattern rows rather than
+a per-bar series, so they are frame-in / frame-out helpers rather than ``.ta``
+expressions.
+
+    import quantwave as qw
+    pats = qw.patterns.harmonic(ohlc_df)   # DataFrame, one row per detected pattern
+
+Attribution
+-----------
+Harmonic patterns (AB=CD, Alternate AB=CD, 5-0) are the work of **Scott M.
+Carney** (HarmonicTrader.com). Carney named and defined these patterns and holds
+trademarks on "Harmonic Trading" and several pattern names. This detector
+implements his published Fibonacci-ratio definitions for interoperability, with
+attribution; it reproduces no source text. See ``qw.patterns.HARMONIC_ATTRIBUTION``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Union
+
+if TYPE_CHECKING:
+    import polars as pl
+
+HARMONIC_ATTRIBUTION = (
+    "Harmonic patterns (AB=CD, Alternate AB=CD, 5-0) are defined by Scott M. "
+    "Carney, Harmonic Trading Vols. 1-2 (2010) and HarmonicTrader.com. "
+    "'Harmonic Trading' and several pattern names are trademarks of Scott M. "
+    "Carney / HarmonicTrader.com."
+)
+
+
+def _pl():
+    import polars as pl
+
+    return pl
+
+
+def _high_low(
+    data: "Union[pl.DataFrame, pl.LazyFrame, tuple, list]",
+    high_col: str,
+    low_col: str,
+) -> "tuple[list[float], list[float]]":
+    pl = _pl()
+    if isinstance(data, pl.LazyFrame):
+        data = data.collect()
+    if isinstance(data, pl.DataFrame):
+        for c in (high_col, low_col):
+            if c not in data.columns:
+                raise ValueError(f"column {c!r} not in DataFrame")
+        return (
+            data[high_col].cast(pl.Float64).to_list(),
+            data[low_col].cast(pl.Float64).to_list(),
+        )
+    # (highs, lows) pair of sequences
+    if isinstance(data, (tuple, list)) and len(data) == 2:
+        highs, lows = data
+        return ([float(x) for x in highs], [float(x) for x in lows])
+    raise ValueError(
+        "data must be an OHLC DataFrame/LazyFrame or a (highs, lows) pair"
+    )
+
+
+def harmonic(
+    data: "Union[pl.DataFrame, pl.LazyFrame, tuple, list]",
+    *,
+    high_col: str = "high",
+    low_col: str = "low",
+    swing_strength: int = 5,
+    ratio_tolerance: float = 0.10,
+    min_score: float = 0.5,
+    min_size_atr: float = 0.0,
+    atr_period: int = 14,
+    detect_abcd: bool = True,
+    detect_alternate_abcd: bool = True,
+    detect_5_0: bool = True,
+) -> "pl.DataFrame":
+    """Detect harmonic patterns (AB=CD, Alternate AB=CD, 5-0).
+
+    Built on the shared MarketStructure swing foundation: confirmed swing pivots
+    are tested against Carney's Fibonacci-ratio gates, and a pattern is emitted
+    only once its completion pivot ``D`` is a *confirmed* swing (so detection is
+    anti-lookahead).
+
+    Args:
+        data: OHLC DataFrame/LazyFrame (uses ``high_col``/``low_col``) or a
+            ``(highs, lows)`` pair of sequences.
+        swing_strength: bar-window radius for swing detection (larger = fewer,
+            more significant pivots).
+        ratio_tolerance: relative tolerance on the Fibonacci ratios (0.10 = ±10%).
+        min_score: minimum ratio-fit score (0-1) to report a pattern.
+        min_size_atr: minimum pattern extent in ATR units (0 disables the filter).
+        atr_period: ATR period used for ``size_atr`` normalization.
+        detect_abcd / detect_alternate_abcd / detect_5_0: enable each family.
+
+    Returns:
+        DataFrame with one row per detected pattern: ``id``, ``kind``
+        (``abcd``/``alternate_abcd``/``5-0``), ``is_bull``, the pivot bars/prices
+        (``x_*`` null for AB=CD), ``score``, the measured ratios (``xa_ext``,
+        ``bc_ab``, ``cd_ab``, ``cd_bc``), the ``prz_low``/``prz_high`` reversal
+        zone, and ``size_atr``.
+    """
+    from quantwave import _patterns
+
+    highs, lows = _high_low(data, high_col, low_col)
+    return _patterns.harmonic(
+        highs,
+        lows,
+        swing_strength,
+        ratio_tolerance,
+        min_score,
+        min_size_atr,
+        atr_period,
+        detect_abcd,
+        detect_alternate_abcd,
+        detect_5_0,
+    )

--- a/quantwave-py/src/lib.rs
+++ b/quantwave-py/src/lib.rs
@@ -16,6 +16,7 @@ use pyo3::prelude::*;
 mod backtest;
 mod bars;
 mod indicators;
+mod patterns;
 pub mod plugins;
 
 #[pymodule]
@@ -39,6 +40,12 @@ fn _lib(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     bars::register(&bars_mod)?;
     sys_modules.set_item("quantwave._bars", &bars_mod)?;
     m.add_submodule(&bars_mod)?;
+
+    // Pattern detection (harmonic) -> quantwave._patterns
+    let patterns_mod = PyModule::new(py, "_patterns")?;
+    patterns::register(&patterns_mod)?;
+    sys_modules.set_item("quantwave._patterns", &patterns_mod)?;
+    m.add_submodule(&patterns_mod)?;
 
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     Ok(())

--- a/quantwave-py/src/patterns.rs
+++ b/quantwave-py/src/patterns.rs
@@ -1,0 +1,100 @@
+//! PyO3 bindings for harmonic pattern detection.
+//!
+//! Like the bar transforms, pattern detection is not a 1:1 `.ta` expression
+//! (it returns a variable number of detected-pattern rows), so it is exposed as
+//! a free function returning a fresh Polars DataFrame — one row per pattern.
+//!
+//! Attribution: the harmonic patterns are the work of Scott M. Carney
+//! (HarmonicTrader.com); see `quantwave_core::indicators::harmonic`.
+
+use polars::prelude::*;
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::prelude::*;
+use pyo3_polars::PyDataFrame;
+use quantwave_core::{HarmonicConfig, HarmonicPattern, harmonic_patterns_batch};
+
+fn patterns_to_frame(pats: &[HarmonicPattern]) -> PolarsResult<DataFrame> {
+    let u = |v: Option<usize>| v.map(|x| x as u32);
+    df![
+        "id" => pats.iter().map(|p| p.id).collect::<Vec<u32>>(),
+        "kind" => pats.iter().map(|p| p.kind.as_str()).collect::<Vec<&str>>(),
+        "is_bull" => pats.iter().map(|p| p.is_bull).collect::<Vec<bool>>(),
+        "x_bar" => pats.iter().map(|p| u(p.x_bar)).collect::<Vec<Option<u32>>>(),
+        "a_bar" => pats.iter().map(|p| p.a_bar as u32).collect::<Vec<u32>>(),
+        "b_bar" => pats.iter().map(|p| p.b_bar as u32).collect::<Vec<u32>>(),
+        "c_bar" => pats.iter().map(|p| p.c_bar as u32).collect::<Vec<u32>>(),
+        "d_bar" => pats.iter().map(|p| p.d_bar as u32).collect::<Vec<u32>>(),
+        "x_price" => pats.iter().map(|p| p.x_price).collect::<Vec<Option<f64>>>(),
+        "a_price" => pats.iter().map(|p| p.a_price).collect::<Vec<f64>>(),
+        "b_price" => pats.iter().map(|p| p.b_price).collect::<Vec<f64>>(),
+        "c_price" => pats.iter().map(|p| p.c_price).collect::<Vec<f64>>(),
+        "d_price" => pats.iter().map(|p| p.d_price).collect::<Vec<f64>>(),
+        "score" => pats.iter().map(|p| p.score).collect::<Vec<f64>>(),
+        "xa_ext" => pats.iter().map(|p| p.xa_ext).collect::<Vec<Option<f64>>>(),
+        "bc_ab" => pats.iter().map(|p| p.bc_ab).collect::<Vec<f64>>(),
+        "cd_ab" => pats.iter().map(|p| p.cd_ab).collect::<Vec<f64>>(),
+        "cd_bc" => pats.iter().map(|p| p.cd_bc).collect::<Vec<f64>>(),
+        "prz_low" => pats.iter().map(|p| p.prz_low).collect::<Vec<f64>>(),
+        "prz_high" => pats.iter().map(|p| p.prz_high).collect::<Vec<f64>>(),
+        "size_atr" => pats.iter().map(|p| p.size_atr).collect::<Vec<f64>>(),
+    ]
+}
+
+/// Detect harmonic patterns (AB=CD, Alternate AB=CD, 5-0) over `(highs, lows)`.
+/// Returns one DataFrame row per detected pattern in completion order.
+#[pyfunction]
+#[pyo3(signature = (
+    highs,
+    lows,
+    swing_strength = 5,
+    ratio_tolerance = 0.10,
+    min_score = 0.5,
+    min_size_atr = 0.0,
+    atr_period = 14,
+    detect_abcd = true,
+    detect_alternate_abcd = true,
+    detect_5_0 = true,
+))]
+#[allow(clippy::too_many_arguments)]
+fn harmonic(
+    highs: Vec<f64>,
+    lows: Vec<f64>,
+    swing_strength: usize,
+    ratio_tolerance: f64,
+    min_score: f64,
+    min_size_atr: f64,
+    atr_period: usize,
+    detect_abcd: bool,
+    detect_alternate_abcd: bool,
+    detect_5_0: bool,
+) -> PyResult<PyDataFrame> {
+    if highs.len() != lows.len() {
+        return Err(PyValueError::new_err(
+            "highs and lows must have equal length",
+        ));
+    }
+    if swing_strength < 1 {
+        return Err(PyValueError::new_err("swing_strength must be >= 1"));
+    }
+    if !(ratio_tolerance > 0.0) {
+        return Err(PyValueError::new_err("ratio_tolerance must be > 0"));
+    }
+    let config = HarmonicConfig {
+        ratio_tolerance,
+        min_score,
+        min_size_atr,
+        atr_period,
+        detect_abcd,
+        detect_alternate_abcd,
+        detect_5_0,
+    };
+    let bars: Vec<(f64, f64)> = highs.into_iter().zip(lows).collect();
+    let pats = harmonic_patterns_batch(&bars, swing_strength, config);
+    let df = patterns_to_frame(&pats).map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+    Ok(PyDataFrame(df))
+}
+
+pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(harmonic, m)?)?;
+    Ok(())
+}

--- a/tests/python/test_patterns.py
+++ b/tests/python/test_patterns.py
@@ -1,0 +1,120 @@
+"""Harmonic pattern detection (quantwave-p2k0.9, slice 4).
+
+Patterns and their Fibonacci-ratio definitions are the work of Scott M. Carney
+(Harmonic Trading Vols. 1-2 / HarmonicTrader.com); see qw.patterns for attribution.
+"""
+
+import polars as pl
+import pytest
+
+import quantwave as qw
+
+STRENGTH = 2
+SPACING = 6
+
+
+def series_from_pivots(pivots, strength=STRENGTH, spacing=SPACING, eps=0.01):
+    """OHLC frame whose confirmed swings land on the given (price, is_high) pivots."""
+    start = strength + 1
+    bars = [start + i * spacing for i in range(len(pivots))]
+    n = start + (len(pivots) - 1) * spacing + strength + 2
+    highs, lows = [], []
+    for i in range(n):
+        if i <= bars[0]:
+            mid = pivots[0][0]
+        elif i >= bars[-1]:
+            mid = pivots[-1][0]
+        else:
+            k = next(j for j, b in enumerate(bars) if b > i)
+            b0, b1 = bars[k - 1], bars[k]
+            v0, v1 = pivots[k - 1][0], pivots[k][0]
+            mid = v0 + (v1 - v0) * (i - b0) / (b1 - b0)
+        highs.append(mid + eps)
+        lows.append(mid - eps)
+    for idx, (price, is_high) in enumerate(pivots):
+        b = bars[idx]
+        if is_high:
+            highs[b], lows[b] = price, price - 2 * eps
+        else:
+            highs[b], lows[b] = price + 2 * eps, price
+    return pl.DataFrame({"high": highs, "low": lows})
+
+
+def detect(pivots):
+    return qw.patterns.harmonic(series_from_pivots(pivots), swing_strength=STRENGTH)
+
+
+def test_bullish_abcd_exact():
+    pats = detect([(110.0, True), (100.0, False), (106.18, True), (96.18, False)])
+    assert pats.columns[:3] == ["id", "kind", "is_bull"]
+    abcd = pats.filter(pl.col("kind") == "abcd")
+    assert abcd.height == 1
+    row = abcd.row(0, named=True)
+    assert row["is_bull"] is True
+    assert row["score"] > 0.9
+    assert row["cd_ab"] == pytest.approx(1.0, abs=0.03)
+    assert row["bc_ab"] == pytest.approx(0.618, abs=0.03)
+    assert row["x_bar"] is None  # AB=CD has no X
+
+
+def test_alternate_abcd_1_27():
+    pats = detect([(110.0, True), (100.0, False), (106.18, True), (93.48, False)])
+    alt = pats.filter(pl.col("kind") == "alternate_abcd")
+    assert alt.height == 1
+    assert alt.row(0, named=True)["cd_ab"] == pytest.approx(1.27, abs=0.04)
+
+
+def test_bullish_5_0_exact():
+    pats = detect(
+        [
+            (100.0, False),
+            (110.0, True),
+            (93.82, False),
+            (126.18, True),
+            (110.0, False),
+        ]
+    )
+    five = pats.filter(pl.col("kind") == "5-0")
+    assert five.height == 1
+    row = five.row(0, named=True)
+    assert row["is_bull"] is True
+    assert row["x_bar"] is not None
+    assert row["cd_bc"] == pytest.approx(0.5, abs=0.03)
+    assert row["score"] > 0.9
+
+
+def test_perturbed_abcd_rejected():
+    # CD = 1.5 x AB is neither AB=CD (1.0) nor Alternate (1.27/1.618) within 10%.
+    pats = detect([(110.0, True), (100.0, False), (106.18, True), (91.18, False)])
+    assert pats.filter(pl.col("kind").is_in(["abcd", "alternate_abcd"])).height == 0
+
+
+def test_bad_retrace_rejected():
+    # C retraces AB by only 0.2 (< 0.382 gate) -> not an AB=CD candidate.
+    pats = detect([(110.0, True), (100.0, False), (102.0, True), (92.0, False)])
+    assert pats.filter(pl.col("kind") == "abcd").height == 0
+
+
+def test_bearish_abcd_detected():
+    pats = detect([(90.0, False), (100.0, True), (93.82, False), (103.82, True)])
+    abcd = pats.filter(pl.col("kind") == "abcd")
+    assert abcd.height == 1
+    assert abcd.row(0, named=True)["is_bull"] is False
+
+
+def test_accepts_high_low_pair_and_attribution():
+    df = series_from_pivots(
+        [(110.0, True), (100.0, False), (106.18, True), (96.18, False)]
+    )
+    pats = qw.patterns.harmonic(
+        (df["high"].to_list(), df["low"].to_list()), swing_strength=2
+    )
+    assert pats.height >= 1
+    assert "Carney" in qw.patterns.HARMONIC_ATTRIBUTION
+
+
+def test_errors():
+    with pytest.raises(Exception):
+        qw.patterns.harmonic(([1.0, 2.0], [1.0]))  # length mismatch
+    with pytest.raises(ValueError):
+        qw.patterns.harmonic(pl.DataFrame({"high": [1.0], "low": [0.0]}), swing_strength=0)


### PR DESCRIPTION
## Summary

Adds **harmonic pattern detection** under a new `quantwave.patterns` namespace — the harmonic-patterns portion of **quantwave-p2k0.9**. Built on the shared `MarketStructure` swing foundation exactly like `GeometricPatternScanner`: confirmed swing pivots are tested against each pattern's Fibonacci-ratio gates, and a pattern is emitted only once its completion pivot `D` is a *confirmed* swing — so detection uses no data from beyond `D` (**anti-lookahead by construction**).

**Surface:** `qw.patterns.harmonic(ohlc_df | (highs, lows), swing_strength=…, ratio_tolerance=…, min_score=…)` → one DataFrame row per pattern (`id, kind, is_bull, X…D bars/prices, score, xa_ext/bc_ab/cd_ab/cd_bc, prz_low/high, size_atr`).
Core: `HarmonicPatternScanner` (`Next`), `HarmonicPattern`/`HarmonicKind`, `harmonic_patterns_batch`.

## Attribution (trademark)

Harmonic Trading is the work of **Scott M. Carney** (HarmonicTrader.com). **"Harmonic Trading" and several pattern names (incl. the 5-0) are his trademarks.** This detector implements his published Fibonacci-ratio definitions for interoperability, *with attribution, reproducing no source text*. Attribution is surfaced in the new docs page and at `qw.patterns.HARMONIC_ATTRIBUTION`. The source books live in `sources/` (gitignored — never committed).

## Cited definitions

- **AB=CD / Alternate AB=CD** — Carney, *Harmonic Trading: Volume One* (2010), Ch. 4, and [harmonictrader.com](https://harmonictrader.com/harmonic-patterns/abcd-pattern/) ([alternate](https://harmonictrader.com/harmonic-patterns/alternate-abcd-pattern/)). C retraces AB 0.382–0.886; CD = AB (or 1.27/1.618 × AB for Alternate). The reciprocal ratio table is applied via the equal-length CD constraint.
- **5-0** — Carney, *Harmonic Trading: Volume Two* (2010), Ch. 3, pp. 78–79, and [harmonictrader.com](https://harmonictrader.com/harmonic-patterns/5-0/). B = 1.13–1.618 of XA; C = 1.618–2.24 of AB; D = 50% of BC and the reciprocal AB=CD. (Sources read via `liteparse`.)

## Tests

- **Rust:** 7 gold/rejection/anti-lookahead tests + 1 **proptest** asserting every emitted pattern is well-formed (anti-lookahead, strictly-ordered pivots, score ≥ threshold, kind-consistent ratios). The proptest caught coincident same-bar pivots from `MarketStructure`; classification now guards for strictly time-ordered pivots (regression seed committed).
- **Python:** 8 tests (bullish/bearish AB=CD, Alternate 1.27, 5-0, perturbation + bad-retrace rejection, tuple input, attribution, errors).

Gate green locally: `cargo clippy -p quantwave-core --all-targets -D warnings` clean, `cargo nextest -p quantwave-core` **570 passed**, rustfmt clean, `pytest test_patterns.py test_bars.py test_gold_parity.py` **54 passed**.

## Docs

New **"Bar Types & Patterns"** guide page (added to the Indicators nav) documenting the harmonic patterns *and* the Renko/range/Kagi bar types from the earlier slices, with full Carney attribution. Validation stats regenerated.

Remaining p2k0.9: Point & Figure bars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)