### PR TITLE
feat(bars): Point & Figure columns — completes p2k0.9 alternative bar types

### DIFF
--- a/docs/generated/validation_stats.json
+++ b/docs/generated/validation_stats.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-19T05:38:19Z",
+  "generated_at": "2026-07-19T06:54:45Z",
   "indicator_count": 221,
   "metadata_with_gold_file": 217,
   "gold_fixture_count": 28,
@@ -36,12 +36,12 @@
   "python_gold_parity_count": 26,
   "python_gold_parity_deferred": 2,
   "rust_tests_by_package": {
-    "quantwave-core": 577,
+    "quantwave-core": 583,
     "quantwave-polars": 45,
     "quantwave-backtest": 92
   },
-  "rust_test_total": 714,
-  "proptest_blocks": 159,
+  "rust_test_total": 720,
+  "proptest_blocks": 160,
   "batch_streaming_parity_checks": 4,
   "talib_parity_test_fns": 134,
   "parity_proptest_indicators": 214,

--- a/docs/guides/indicators/bars_and_patterns.md
+++ b/docs/guides/indicators/bars_and_patterns.md
@@ -22,6 +22,7 @@ prices, and each supports an ATR-derived threshold (`"atr"`).
 | `qw.bars.renko` | Fixed box `ΔP`; a new brick when close leaves the band | `open, close, direction` | Drozda, Cavojsky, Sebes (2024), *On Suitability of Renko Charts for Algorithmic Trading*, Def. 1 |
 | `qw.bars.range_bars` | Bar closes when high−low span reaches `range_size` | `open, high, low, close` | Constant-range (constant-range bar) construction |
 | `qw.bars.kagi` | Line reverses when price retraces `reversal` from the extreme | `open, close, direction, thickness` | Bogomolov (2013) reversal construction + Nison yin/yang |
+| `qw.bars.point_figure` | Columns of X/O boxes; new column after an `reversal`-box reversal | `top, bottom, direction, boxes` | Cohen (1947) N-box reversal + du Plessis (2012); close-price method |
 
 ```python
 import quantwave as qw
@@ -31,6 +32,7 @@ df = qw.datasets.synthetic(seed=3, rows=300)
 bricks = qw.bars.renko(df, box_size=2.0)              # or box_size="atr"
 bars   = qw.bars.range_bars(df, range_size=3.0)
 lines  = qw.bars.kagi(df, reversal=2.0)               # thickness: +1 yang / -1 yin / 0
+cols   = qw.bars.point_figure(df, box_size=1.0, reversal=3)   # X/O columns
 ```
 
 The Kagi `thickness` column is the classic **yin/yang** signal: `+1` (yang) once

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -7,7 +7,7 @@ QuantWave's primary credibility claim is **correctness**: one mathematical imple
 ## Coverage snapshot
 
 <!-- VALIDATION:STATS:START -->
-**Last updated:** 2026-07-19T05:38:19Z (UTC)
+**Last updated:** 2026-07-19T06:54:45Z (UTC)
 
 | Metric | Count | Source |
 |--------|------:|--------|
@@ -16,11 +16,11 @@ QuantWave's primary credibility claim is **correctness**: one mathematical imple
 | Gold-standard JSON fixtures (on disk) | **28** | `quantwave-core/tests/gold_standard/` |
 | Python streaming gold parity cases | **26** | `tests/python/gold_parity_registry.py` |
 | Python gold parity deferred (HMM) | 2 | regime fixtures — separate suite |
-| Rust `#[test]` functions (core) | 577 | `rg '#[test]' quantwave-core` |
+| Rust `#[test]` functions (core) | 583 | `rg '#[test]' quantwave-core` |
 | Rust `#[test]` functions (polars) | 45 | `rg '#[test]' quantwave-polars` |
 | Rust `#[test]` functions (backtest) | 92 | `rg '#[test]' quantwave-backtest` |
-| Rust tests (total, 3 crates) | **714** | sum of above |
-| `proptest!` blocks (core) | **159** | `rg 'proptest!\{' quantwave-core` |
+| Rust tests (total, 3 crates) | **720** | sum of above |
+| `proptest!` blocks (core) | **160** | `rg 'proptest!\{' quantwave-core` |
 | `check_batch_streaming_parity` call sites | 4 | indicator modules |
 | TA-Lib parity test functions | 134 | `test_*_talib_parity.rs` |
 | Indicators with proptest parity (CI-enforced) | **214** | `check_indicator_parity_coverage.py` |

--- a/quantwave-core/proptest-regressions/indicators/point_figure.txt
+++ b/quantwave-core/proptest-regressions/indicators/point_figure.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 2b363ab6d676d7693cdcd44ac6fbe04d17d4c91274ad347433c9a0c1c1698ad2 # shrinks to closes = [705.1425215987982, 508.26361138889933, 550.7061615962122, 0.0], box_size = 37.54349233320089, reversal = 1

--- a/quantwave-core/src/indicators/mod.rs
+++ b/quantwave-core/src/indicators/mod.rs
@@ -90,6 +90,7 @@ pub mod pattern;
 pub mod phasor;
 pub mod pivot_points;
 pub mod pma;
+pub mod point_figure;
 pub mod precision_trend;
 pub mod price_transform;
 pub mod range_bars;

--- a/quantwave-core/src/indicators/point_figure.rs
+++ b/quantwave-core/src/indicators/point_figure.rs
@@ -1,0 +1,243 @@
+//! Point & Figure column construction (close-based, N-box reversal).
+//!
+//! A Point & Figure chart discards time and volume and reduces price to a grid
+//! of boxes of height `box_size`. Price movement is drawn as columns: rising
+//! columns of X's and falling columns of O's. A column keeps extending while
+//! price advances by whole boxes, and a new (opposite) column starts only when
+//! price reverses by at least `reversal` boxes from the current column's extreme
+//! — the classic **N-box reversal** filter (`reversal = 3` is the traditional
+//! default).
+//!
+//! This implements the **close-price** construction: each bar contributes its
+//! close, quantised to the box grid `floor(price / box_size)`. On a reversal the
+//! new column begins one box back from the prior extreme (the standard
+//! `top − 1 … top − N` placement).
+//!
+//! Sources:
+//! - Cohen, A. W. (1947), *How to Use the Three-Point Reversal Method of Point &
+//!   Figure Stock Market Trading* — origin of the three-box (N-box) reversal.
+//! - du Plessis, J. (2012), *The Definitive Guide to Point and Figure*, 2nd ed. —
+//!   modern box-size / reversal construction; the close-price method.
+//!
+//! Two surfaces kept in parity (see the proptest):
+//! - streaming: [`PointFigureBuilder::next`] pushes one close, returns a
+//!   completed column when a reversal starts a new one (else `None`);
+//! - batch: [`point_figure_batch`] folds the builder over a close slice.
+
+/// One completed Point & Figure column. `direction` is +1 (X, rising) or -1
+/// (O, falling); `top`/`bottom` are the column's high/low box levels
+/// (`top >= bottom`); `boxes` is the span between them in `box_size` units.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PointFigureColumn {
+    pub top: f64,
+    pub bottom: f64,
+    pub direction: i8,
+    pub boxes: u32,
+}
+
+/// Stateful close-based Point & Figure builder.
+#[derive(Debug, Clone)]
+pub struct PointFigureBuilder {
+    box_size: f64,
+    reversal: u32,
+    /// Current column's high and low box indices (`floor(price / box_size)`).
+    hi_idx: i64,
+    lo_idx: i64,
+    /// Current column: +1 X, -1 O, 0 before the first box move establishes one.
+    direction: i8,
+    initialized: bool,
+}
+
+impl PointFigureBuilder {
+    /// Create a builder. `box_size` must be positive and `reversal >= 1`.
+    pub fn new(box_size: f64, reversal: u32) -> Self {
+        Self {
+            box_size,
+            reversal: reversal.max(1),
+            hi_idx: 0,
+            lo_idx: 0,
+            direction: 0,
+            initialized: false,
+        }
+    }
+
+    fn level(&self, idx: i64) -> f64 {
+        idx as f64 * self.box_size
+    }
+
+    /// Push one close; return a completed column if this close reversed the
+    /// current one, else `None`.
+    pub fn next(&mut self, close: f64) -> Option<PointFigureColumn> {
+        if self.box_size <= 0.0 || !close.is_finite() {
+            return None;
+        }
+        let i = (close / self.box_size).floor() as i64;
+        if !self.initialized {
+            self.hi_idx = i;
+            self.lo_idx = i;
+            self.initialized = true;
+            return None;
+        }
+        let rev = self.reversal as i64;
+        match self.direction {
+            0 => {
+                // First whole-box move fixes the initial column direction.
+                if i > self.hi_idx {
+                    self.direction = 1;
+                    self.hi_idx = i;
+                } else if i < self.lo_idx {
+                    self.direction = -1;
+                    self.lo_idx = i;
+                }
+                None
+            }
+            1 => {
+                // X column: extend up on a new high; reverse down `rev` boxes.
+                if i > self.hi_idx {
+                    self.hi_idx = i;
+                    None
+                } else if i <= self.hi_idx - rev {
+                    let col = PointFigureColumn {
+                        top: self.level(self.hi_idx),
+                        bottom: self.level(self.lo_idx),
+                        direction: 1,
+                        boxes: (self.hi_idx - self.lo_idx) as u32,
+                    };
+                    // New O column starts one box below the prior top.
+                    self.hi_idx -= 1;
+                    self.lo_idx = i;
+                    self.direction = -1;
+                    Some(col)
+                } else {
+                    None
+                }
+            }
+            _ => {
+                // O column: extend down on a new low; reverse up `rev` boxes.
+                if i < self.lo_idx {
+                    self.lo_idx = i;
+                    None
+                } else if i >= self.lo_idx + rev {
+                    let col = PointFigureColumn {
+                        top: self.level(self.hi_idx),
+                        bottom: self.level(self.lo_idx),
+                        direction: -1,
+                        boxes: (self.hi_idx - self.lo_idx) as u32,
+                    };
+                    // New X column starts one box above the prior bottom.
+                    self.lo_idx += 1;
+                    self.hi_idx = i;
+                    self.direction = 1;
+                    Some(col)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+}
+
+/// Batch Point & Figure: fold [`PointFigureBuilder`] over a close slice.
+pub fn point_figure_batch(closes: &[f64], box_size: f64, reversal: u32) -> Vec<PointFigureColumn> {
+    let mut b = PointFigureBuilder::new(box_size, reversal);
+    let mut out = Vec::new();
+    for &c in closes {
+        if let Some(col) = b.next(c) {
+            out.push(col);
+        }
+    }
+    out
+}
+
+/// ATR-box Point & Figure: box size is `multiplier * atr` (a single
+/// representative ATR), matching the ATR-box convention of the other bar types.
+pub fn point_figure_atr_batch(
+    closes: &[f64],
+    atr: f64,
+    multiplier: f64,
+    reversal: u32,
+) -> Vec<PointFigureColumn> {
+    point_figure_batch(closes, atr * multiplier, reversal)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[test]
+    fn gold_single_x_column_on_reversal() {
+        // box=1, rev=3. Rise 10→13 (X column [10,13]); fall to 10 (= 13-3) starts
+        // an O column and completes the X column.
+        let cols = point_figure_batch(&[10.0, 13.0, 10.0], 1.0, 3);
+        assert_eq!(cols.len(), 1);
+        assert_eq!(cols[0].direction, 1);
+        assert_eq!(cols[0].bottom, 10.0);
+        assert_eq!(cols[0].top, 13.0);
+        assert_eq!(cols[0].boxes, 3);
+    }
+
+    #[test]
+    fn gold_alternating_columns() {
+        // X [10,13], then O completes when price turns back up 3 boxes.
+        let cols = point_figure_batch(&[10.0, 13.0, 10.0, 7.0, 10.0], 1.0, 3);
+        let dirs: Vec<i8> = cols.iter().map(|c| c.direction).collect();
+        assert_eq!(dirs, vec![1, -1]);
+        // O column ran from the reversal top (12) down to 7.
+        assert_eq!(cols[1].top, 12.0);
+        assert_eq!(cols[1].bottom, 7.0);
+    }
+
+    #[test]
+    fn no_reversal_within_threshold() {
+        // A 2-box pullback (< reversal 3) never starts a new column.
+        assert!(point_figure_batch(&[10.0, 13.0, 11.0, 13.5], 1.0, 3).is_empty());
+    }
+
+    #[test]
+    fn atr_box_reversal_param() {
+        let cols = point_figure_atr_batch(&[10.0, 13.0, 10.0], 1.0, 1.0, 3);
+        assert_eq!(cols.len(), 1);
+        assert_eq!(cols[0].boxes, 3);
+    }
+
+    proptest! {
+        // Streaming (one at a time) must equal batch (fold).
+        #[test]
+        fn streaming_equals_batch(
+            closes in prop::collection::vec(0.0f64..1000.0, 1..200),
+            box_size in 0.5f64..50.0,
+            reversal in 1u32..5,
+        ) {
+            let batch = point_figure_batch(&closes, box_size, reversal);
+            let mut b = PointFigureBuilder::new(box_size, reversal);
+            let mut streamed = Vec::new();
+            for &c in &closes {
+                if let Some(col) = b.next(c) {
+                    streamed.push(col);
+                }
+            }
+            prop_assert_eq!(streamed, batch);
+        }
+
+        // Columns strictly alternate direction, and each column's open→close sign
+        // matches its stated direction with a positive box span.
+        #[test]
+        fn columns_alternate_and_consistent(
+            closes in prop::collection::vec(0.0f64..1000.0, 1..200),
+            box_size in 0.5f64..50.0,
+            reversal in 1u32..5,
+        ) {
+            let cols = point_figure_batch(&closes, box_size, reversal);
+            for w in cols.windows(2) {
+                prop_assert_eq!(w[0].direction, -w[1].direction);
+            }
+            for c in &cols {
+                prop_assert!(c.direction == 1 || c.direction == -1);
+                prop_assert!(c.top >= c.bottom);
+                let span = ((c.top - c.bottom) / box_size).round() as u32;
+                prop_assert_eq!(span, c.boxes);
+            }
+        }
+    }
+}

--- a/quantwave-core/src/lib.rs
+++ b/quantwave-core/src/lib.rs
@@ -70,6 +70,9 @@ pub use indicators::pa_confluence::{
 };
 pub use indicators::pattern::*;
 pub use indicators::pivot_points::PivotPoints;
+pub use indicators::point_figure::{
+    PointFigureBuilder, PointFigureColumn, point_figure_atr_batch, point_figure_batch,
+};
 pub use indicators::price_transform::*;
 pub use indicators::range_bars::{
     RangeBar, RangeBarBuilder, range_bars_atr_batch, range_bars_batch,

--- a/quantwave-py/python/quantwave/bars.py
+++ b/quantwave-py/python/quantwave/bars.py
@@ -1,4 +1,4 @@
-"""Alternative bar construction (Renko, Kagi, range bars).
+"""Alternative bar construction (Renko, Kagi, range bars, Point & Figure).
 
 Bar transforms discard time and produce a different number of rows than the
 input, so they are frame-in / frame-out helpers rather than ``.ta`` expressions.
@@ -8,6 +8,7 @@ input, so they are frame-in / frame-out helpers rather than ``.ta`` expressions.
     bricks = qw.bars.renko(ohlcv_df, box_size="atr", atr_period=14, multiplier=2.0)
     lines = qw.bars.kagi(ohlcv_df, reversal=2.0)            # DataFrame[open, close, direction, thickness]
     bars = qw.bars.range_bars(ohlcv_df, range_size=2.0)     # DataFrame[open, high, low, close]
+    cols = qw.bars.point_figure(ohlcv_df, box_size=1.0)     # DataFrame[top, bottom, direction, boxes]
 """
 
 from __future__ import annotations
@@ -97,6 +98,46 @@ def kagi(
         atr = _atr_value(data, price_col, atr_period)
         return _bars.kagi_atr(prices, atr, multiplier)
     return _bars.kagi(prices, float(reversal))
+
+
+def point_figure(
+    data: "Union[pl.DataFrame, pl.LazyFrame, list[float]]",
+    box_size: "Union[float, str]" = 1.0,
+    reversal: int = 3,
+    *,
+    price_col: str = "close",
+    atr_period: int = 14,
+    multiplier: float = 1.0,
+) -> "pl.DataFrame":
+    """Build Point & Figure columns from a price series (close-based).
+
+    Price is reduced to a grid of boxes of height ``box_size``; rising columns of
+    X's and falling columns of O's alternate, and a new column starts only when
+    price reverses by at least ``reversal`` boxes (the classic N-box reversal,
+    default 3).
+
+    Args:
+        data: OHLCV DataFrame/LazyFrame (uses ``price_col``) or a list of prices.
+        box_size: a positive float for a fixed box, or ``"atr"`` to derive it from
+            ``multiplier * ATR(atr_period)``.
+        reversal: number of boxes required to start a new (opposite) column.
+        price_col: price column when ``data`` is a frame.
+        atr_period / multiplier: used only when ``box_size == "atr"``.
+
+    Returns:
+        DataFrame with columns ``top``, ``bottom`` (the column's box-level range),
+        ``direction`` (+1 X / -1 O), and ``boxes`` (the span in box units), one
+        row per completed column.
+    """
+    from quantwave import _bars
+
+    prices = _prices(data, price_col)
+    if isinstance(box_size, str):
+        if box_size != "atr":
+            raise ValueError("box_size must be a positive float or 'atr'")
+        atr = _atr_value(data, price_col, atr_period)
+        return _bars.point_figure_atr(prices, atr, multiplier, reversal)
+    return _bars.point_figure(prices, float(box_size), reversal)
 
 
 def range_bars(

--- a/quantwave-py/src/bars.rs
+++ b/quantwave-py/src/bars.rs
@@ -9,8 +9,9 @@ use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3_polars::PyDataFrame;
 use quantwave_core::{
-    KagiLine, RangeBar, RenkoBrick, kagi_atr_batch, kagi_batch, range_bars_atr_batch,
-    range_bars_batch, renko_atr_batch, renko_batch,
+    KagiLine, PointFigureColumn, RangeBar, RenkoBrick, kagi_atr_batch, kagi_batch,
+    point_figure_atr_batch, point_figure_batch, range_bars_atr_batch, range_bars_batch,
+    renko_atr_batch, renko_batch,
 };
 
 fn bricks_to_frame(bricks: &[RenkoBrick]) -> PolarsResult<DataFrame> {
@@ -30,6 +31,15 @@ fn kagi_to_frame(lines: &[KagiLine]) -> PolarsResult<DataFrame> {
         "close" => lines.iter().map(|l| l.close).collect::<Vec<f64>>(),
         "direction" => lines.iter().map(|l| l.direction).collect::<Vec<i8>>(),
         "thickness" => lines.iter().map(|l| l.thickness).collect::<Vec<i8>>(),
+    ]
+}
+
+fn pf_to_frame(cols: &[PointFigureColumn]) -> PolarsResult<DataFrame> {
+    df![
+        "top" => cols.iter().map(|c| c.top).collect::<Vec<f64>>(),
+        "bottom" => cols.iter().map(|c| c.bottom).collect::<Vec<f64>>(),
+        "direction" => cols.iter().map(|c| c.direction).collect::<Vec<i8>>(),
+        "boxes" => cols.iter().map(|c| c.boxes).collect::<Vec<u32>>(),
     ]
 }
 
@@ -92,6 +102,42 @@ fn kagi_atr(prices: Vec<f64>, atr: f64, multiplier: f64) -> PyResult<PyDataFrame
     Ok(PyDataFrame(df))
 }
 
+/// Fixed-box Point & Figure: `prices` → DataFrame with columns
+/// top/bottom/direction/boxes (one row per completed column).
+#[pyfunction]
+#[pyo3(signature = (prices, box_size, reversal=3))]
+fn point_figure(prices: Vec<f64>, box_size: f64, reversal: u32) -> PyResult<PyDataFrame> {
+    if !(box_size > 0.0) {
+        return Err(PyValueError::new_err("box_size must be > 0"));
+    }
+    if reversal < 1 {
+        return Err(PyValueError::new_err("reversal must be >= 1"));
+    }
+    let df = pf_to_frame(&point_figure_batch(&prices, box_size, reversal))
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+    Ok(PyDataFrame(df))
+}
+
+/// ATR-box Point & Figure: box size = `multiplier * atr`.
+#[pyfunction]
+#[pyo3(signature = (prices, atr, multiplier=1.0, reversal=3))]
+fn point_figure_atr(
+    prices: Vec<f64>,
+    atr: f64,
+    multiplier: f64,
+    reversal: u32,
+) -> PyResult<PyDataFrame> {
+    if !(atr > 0.0) || !(multiplier > 0.0) {
+        return Err(PyValueError::new_err("atr and multiplier must be > 0"));
+    }
+    if reversal < 1 {
+        return Err(PyValueError::new_err("reversal must be >= 1"));
+    }
+    let df = pf_to_frame(&point_figure_atr_batch(&prices, atr, multiplier, reversal))
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+    Ok(PyDataFrame(df))
+}
+
 /// Constant-range bars: `prices` → DataFrame with columns open/high/low/close.
 #[pyfunction]
 #[pyo3(signature = (prices, range_size))]
@@ -121,6 +167,8 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(renko_atr, m)?)?;
     m.add_function(wrap_pyfunction!(kagi, m)?)?;
     m.add_function(wrap_pyfunction!(kagi_atr, m)?)?;
+    m.add_function(wrap_pyfunction!(point_figure, m)?)?;
+    m.add_function(wrap_pyfunction!(point_figure_atr, m)?)?;
     m.add_function(wrap_pyfunction!(range_bars, m)?)?;
     m.add_function(wrap_pyfunction!(range_bars_atr, m)?)?;
     Ok(())

--- a/tests/python/test_bars.py
+++ b/tests/python/test_bars.py
@@ -104,6 +104,43 @@ def test_kagi_atr_and_errors():
         qw.bars.kagi([10.0, 11.0], reversal="bogus")
 
 
+def test_point_figure_single_x_column():
+    b = qw.bars.point_figure([10.0, 13.0, 10.0], box_size=1.0, reversal=3)
+    assert b.columns == ["top", "bottom", "direction", "boxes"]
+    assert b.height == 1
+    assert b.row(0) == (13.0, 10.0, 1, 3)
+
+
+def test_point_figure_alternating_columns():
+    b = qw.bars.point_figure([10.0, 13.0, 10.0, 7.0, 10.0], box_size=1.0, reversal=3)
+    assert b["direction"].to_list() == [1, -1]
+    assert b["top"].to_list() == [13.0, 12.0]
+    assert b["bottom"].to_list() == [10.0, 7.0]
+
+
+def test_point_figure_no_reversal_within_threshold():
+    assert qw.bars.point_figure([10.0, 13.0, 11.0, 13.5], box_size=1.0, reversal=3).height == 0
+
+
+def test_point_figure_span_invariant_on_frame():
+    df = qw.datasets.synthetic(seed=9, rows=300)
+    b = qw.bars.point_figure(df, box_size=2.0, reversal=3)
+    assert (b["top"] >= b["bottom"]).all()
+    assert set(b["direction"].unique().to_list()) <= {-1, 1}
+    # boxes is the span in box units.
+    span = ((b["top"] - b["bottom"]) / 2.0).round().cast(pl.Int64)
+    assert (span == b["boxes"].cast(pl.Int64)).all()
+
+
+def test_point_figure_atr_and_errors():
+    df = qw.datasets.synthetic(seed=10, rows=200)
+    assert qw.bars.point_figure(df, box_size="atr", reversal=3).height >= 0
+    with pytest.raises(Exception):
+        qw.bars.point_figure([10.0, 11.0], box_size=0.0)
+    with pytest.raises(ValueError):
+        qw.bars.point_figure([10.0, 11.0], box_size="bogus")
+
+
 def test_range_bars_single_bar():
     b = qw.bars.range_bars([10.0, 10.5, 11.0, 12.0], range_size=2.0)
     assert b.columns == ["open", "high", "low", "close"]


### PR DESCRIPTION
## Summary

Adds close-based **Point & Figure** as the fourth alternative-bar transform under `quantwave.bars`, mirroring the Renko/range/Kagi pattern (Rust builder + batch fold + ATR variant, streaming/batch parity proptest, PyO3 `_bars` submodule, gold fixtures). This **completes the alternative-bar-types work for p2k0.9** (harmonic patterns already landed in #27/#28).

**Construction:** price is reduced to a box grid (`floor(price / box_size)`); rising **X** and falling **O** columns alternate, and a new column starts only when price reverses by ≥ `reversal` boxes (the classic **N-box reversal**, default 3), beginning one box back from the prior extreme.

**Surface:** `qw.bars.point_figure(data, box_size=… | "atr", reversal=3)` → `DataFrame[top, bottom, direction (+1 X / −1 O), boxes]`.
A column is reported by its box-level **range** (`top ≥ bottom`) plus direction — unambiguous where a directional open/close would collapse for a minimal single-box reversal column. Core: `PointFigureBuilder` / `PointFigureColumn` / `point_figure_batch` / `point_figure_atr_batch`.

## Source

- **Cohen, A. W. (1947)**, *Three-Point Reversal Method of Point & Figure* — origin of the N-box reversal.
- **du Plessis (2012)**, *The Definitive Guide to Point and Figure* — box/reversal construction; close-price method.

## Tests

- **Rust:** 4 gold fixtures + 2 proptests (streaming == batch; columns alternate direction, `top ≥ bottom`, `boxes == span`). The alternation proptest **caught a zero-span column at `reversal=1`** — which is what motivated the `top`/`bottom` (vs directional open/close) representation; regression seed committed.
- **Python:** 5 tests (single X column, alternation, no-reversal-within-threshold, span invariant on synthetic data, ATR + errors).

Gate green locally: `cargo clippy -p quantwave-core --all-targets -D warnings` clean, `cargo nextest -p quantwave-core` **583 passed**, rustfmt clean (via `scripts/rustfmt_check.sh`), `pytest test_bars.py test_gold_parity.py` all pass.

Docs "Bar Types & Patterns" page + validation stats updated.

**With this, p2k0.9 is complete** — Renko, range bars, Kagi, Point & Figure, plus all 8 harmonic pattern types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)