### PR TITLE
fix(core): relax gap_momentum parity tolerance to max_relative=1e-9 (601d)

### DIFF
--- a/quantwave-core/proptest-regressions/indicators/gap_momentum.txt
+++ b/quantwave-core/proptest-regressions/indicators/gap_momentum.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 5a29558ad989b0af5fd10bc696a30259df3a5c204838706cf4b7c2f439bf18ae # shrinks to inputs = [(10.0, 18.55259643258196), (10.0, 10.0), ... ]

--- a/quantwave-core/src/indicators/gap_momentum.rs
+++ b/quantwave-core/src/indicators/gap_momentum.rs
@@ -177,8 +177,8 @@ mod tests {
             }
 
             for (s, b) in streaming_results.iter().zip(batch_results.iter()) {
-                approx::assert_relative_eq!(s.0, b.0, epsilon = 1e-10);
-                approx::assert_relative_eq!(s.1, b.1, epsilon = 1e-10);
+                approx::assert_relative_eq!(s.0, b.0, max_relative = 1e-9);
+                approx::assert_relative_eq!(s.1, b.1, max_relative = 1e-9);
             }
         }
     }


### PR DESCRIPTION
Fixes the intermittent `test_gap_momentum_parity` flake (bead quantwave-601d).

**Root cause:** floating-point non-associativity between the streaming and batch summation paths — the two agreed to ~13 significant figures (~1e-14 relative), but the assertion only passed `epsilon`, leaving approx's default `max_relative` (~2.2e-16) in force, far too tight for O(1e4) accumulated sums. Not a logic error.

**Fix:** both output components now use a magnitude-appropriate `max_relative = 1e-9`, and the shrunk regression seed is committed so the case is always re-tested.

**Verified:** `PROPTEST_CASES=20000` gap_momentum parity green; full `quantwave-core` suite 583/583; clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)